### PR TITLE
Make importing easier for users.

### DIFF
--- a/lib/fs/index.js
+++ b/lib/fs/index.js
@@ -1,0 +1,5 @@
+const { FileSystem } = require('./filesystem');
+
+module.exports = {
+  FileSystem,
+};

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,8 +1,7 @@
 const {
-  Client, logger, normPath, encodePath,
-} = require('./rest/client');
-const { BasicClient } = require('./rest/basic');
-const { FileSystem } = require('./fs/filesystem');
+  Client, BasicClient, logger, normPath, encodePath,
+} = require('./rest');
+const { FileSystem } = require('./fs');
 
 module.exports = {
   Client,

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,0 +1,14 @@
+const {
+  Client, logger, normPath, encodePath,
+} = require('./rest/client');
+const { BasicClient } = require('./rest/basic');
+const { FileSystem } = require('./fs/filesystem');
+
+module.exports = {
+  Client,
+  BasicClient,
+  FileSystem,
+  normPath,
+  encodePath,
+  logger,
+};

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,5 +1,5 @@
 const {
-  Client, BasicClient, logger, normPath, encodePath,
+  Client, BasicClient, logger,
 } = require('./rest');
 const { FileSystem } = require('./fs');
 
@@ -7,7 +7,5 @@ module.exports = {
   Client,
   BasicClient,
   FileSystem,
-  normPath,
-  encodePath,
   logger,
 };

--- a/lib/rest/index.js
+++ b/lib/rest/index.js
@@ -1,12 +1,10 @@
 const {
-  Client, normPath, encodePath, logger,
+  Client, logger,
 } = require('./client');
 const { BasicClient } = require('./basic');
 
 module.exports = {
   Client,
   BasicClient,
-  normPath,
-  encodePath,
   logger,
 };

--- a/lib/rest/index.js
+++ b/lib/rest/index.js
@@ -1,0 +1,12 @@
+const {
+  Client, normPath, encodePath, logger,
+} = require('./client');
+const { BasicClient } = require('./basic');
+
+module.exports = {
+  Client,
+  BasicClient,
+  normPath,
+  encodePath,
+  logger,
+};

--- a/tests/test_fs.js
+++ b/tests/test_fs.js
@@ -1,8 +1,7 @@
 const nock = require('nock');
 const assert = require('assert');
 
-const smartfile = require('../lib/rest/client');
-const smartfileFS = require('../lib/fs/filesystem');
+const smartfile = require('../lib');
 
 const API_URL = 'http://fakeapi.foo/';
 
@@ -23,7 +22,7 @@ describe('File System Abstraction', () => {
 
   beforeEach('', (done) => {
     const rest = new smartfile.Client({ baseUrl: API_URL });
-    sffs = new smartfileFS.FileSystem(rest);
+    sffs = new smartfile.FileSystem(rest);
     server = nock(API_URL);
 
     done();

--- a/tests/test_rest.js
+++ b/tests/test_rest.js
@@ -4,8 +4,11 @@ const { morph } = require('mock-env');
 const streams = require('memory-streams');
 
 const {
-  logger, normPath, encodePath, Client, BasicClient,
+  logger, Client, BasicClient,
 } = require('../lib');
+const {
+  normPath, encodePath,
+} = require('../lib/rest/client');
 
 const API_URL = 'http://fakeapi.foo/';
 

--- a/tests/test_rest.js
+++ b/tests/test_rest.js
@@ -4,9 +4,8 @@ const { morph } = require('mock-env');
 const streams = require('memory-streams');
 
 const {
-  logger, normPath, encodePath, Client,
-} = require('../lib/rest/client');
-const { BasicClient } = require('../lib/rest/basic');
+  logger, normPath, encodePath, Client, BasicClient,
+} = require('../lib');
 
 const API_URL = 'http://fakeapi.foo/';
 


### PR DESCRIPTION
The linter asked me to break files into one class per file. I like that so I did it. However, it makes importing more difficult for users. I created an `index.js` to collect all the "public" objects into the root namespace...

```node
const Client = require('rest/client');
const BasicClient = require('rest/basic');

//is now:

const { Client, BasicClient } = require('smartfile');
```