### PR TITLE
Add metrics for higher-level calls.

### DIFF
--- a/lib/fs/filesystem.js
+++ b/lib/fs/filesystem.js
@@ -25,8 +25,7 @@ const CACHE = new prom.Summary({
 function operationWrapper(self, opName, opArgs, callback) {
   const end = OPERATION.startTimer({ opName });
   return self[opName].apply(self, [...opArgs, (e, ...args) => {
-    const status = (e) ? 'error' : 'success';
-    end({ status });
+    end({ status: (e) ? 'error' : 'success' });
     if (callback) {
       callback(e, ...args);
     }
@@ -138,6 +137,7 @@ class FileSystem {
     // https://nodejs.org/api/fs.html#fs_fs_open_path_flags_mode_callback
     let file = null;
     let callback;
+    const end = OPERATION.startTimer({ opName: 'read' });
 
     // Shift arguments.
     if (typeof _mode === 'function') {
@@ -173,20 +173,27 @@ class FileSystem {
           throw new Error(`invalid flags: ${flags} (${accessType})`);
       }
     } catch (e) {
-      return callback(e);
+      callback(e);
+      end({ status: 'error' });
+      return null;
     }
+
+    end({ status: 'success' });
     return file;
   }
 
   close(fd, callback) {
     const file = this.fds[fd];
+    const end = OPERATION.startTimer({ opName: 'read' });
 
     if (!file) {
       callback(new Error(`invalid fd ${fd}`));
+      end({ status: 'error' });
       return;
     }
 
     file.close(callback);
+    end({ status: 'success' });
   }
 
   fstat(fd, callback) {
@@ -203,13 +210,16 @@ class FileSystem {
   read(fd, buffer, offset, length, position, callback) {
     // https://nodejs.org/api/fs.html#fs_fs_read_fd_buffer_offset_length_position_callback
     const file = this.fds[fd];
+    const end = OPERATION.startTimer({ opName: 'read' });
 
     if (!file) {
       callback(new Error(`invalid fd ${fd}`));
+      end({ status: 'error' });
       return;
     }
 
     file.read(buffer, offset, length, position, callback);
+    end({ status: 'success' });
   }
 
   readFile(path, _options, _callback) {
@@ -217,6 +227,7 @@ class FileSystem {
     let buffer = Buffer.alloc();
     let pos = 0;
     let callback;
+    const end = OPERATION.startTimer({ opName: 'readFile' });
 
     // Shift arguments.
     if (typeof _options === 'function') {
@@ -228,6 +239,7 @@ class FileSystem {
     this.open(path, 'r', null, (openError, fd) => {
       if (openError) {
         callback(openError);
+        end({ status: 'error' });
         return;
       }
 
@@ -237,10 +249,12 @@ class FileSystem {
         this.read(fd, chunk, 0, 16384, pos, (readError, bytesRead) => {
           if (readError) {
             callback(readError);
+            end({ status: 'error' });
             return;
           }
           if (bytesRead === 0) {
             callback(null, buffer);
+            end({ status: 'success' });
             return;
           }
 
@@ -259,19 +273,23 @@ class FileSystem {
     // https://nodejs.org/api/fs.html#fs_fs_write_fd_buffer_offset_length_position_callback
     // https://nodejs.org/api/fs.html#fs_fs_write_fd_string_position_encoding_callback
     const file = this.fds[fd];
+    const end = OPERATION.startTimer({ opName: 'read' });
 
     if (!file) {
       callback(new Error(`invalid fd ${fd}`));
+      end({ status: 'error' });
       return;
     }
 
     file.write(buffer, offset, length, position, callback);
+    end({ status: 'success' });
   }
 
   writeFile(path, buffer, _options, _callback) {
     // https://nodejs.org/api/fs.html#fs_fs_writefile_file_data_options_callback
     let pos = 0;
     let callback;
+    const end = OPERATION.startTimer({ opName: 'writeFile' });
 
     // Shift arguments.
     if (typeof _options === 'function') {
@@ -283,6 +301,7 @@ class FileSystem {
     this.open(path, 'w', null, (openError, fd) => {
       if (openError) {
         callback(openError);
+        end({ status: 'error' });
         return;
       }
 
@@ -290,12 +309,14 @@ class FileSystem {
         this.write(fd, buffer, pos, 16384, pos, (writeError, bytesWritten, chunk) => {
           if (writeError) {
             callback(writeError);
+            end({ status: 'error' });
             return;
           }
 
           pos += bytesWritten;
           if (bytesWritten === chunk.byteLength) {
             callback(null);
+            end({ status: 'success' });
             return;
           }
 
@@ -334,6 +355,8 @@ class FileSystem {
   }
 
   readdirstats(path, callback, opts) {
+    const end = OPERATION.startTimer({ opName: 'readdirstats' });
+
     const options = {
       incremental: false,
       ...opts,
@@ -355,12 +378,14 @@ class FileSystem {
     this.rest.info(path, (e, page) => {
       if (e) {
         callback(e);
+        end({ status: 'error' });
         return;
       }
 
       // Last page, call callback.
       if (page === null) {
         // Not that infos is null when incremental.
+        end({ status: 'success' });
         callback(null, infos);
         return;
       }


### PR DESCRIPTION
@cabarnes I decided to add metrics to some of the high-level calls too. I had omitted them at first because they don't map directly to API calls, but some like `open()` and `close()` do read and write files. If for no other reason it would be nice to see how often they are called.

My goal with these metrics is to report them along with the service level metrics in `ftpd`, `sftpd`, and `davd`. I want to give visibility into their performance.

I did omit `fstat()` because it just forwards to `stat()` which has metrics.