### PR TITLE
Export metrics from package root.

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,5 @@
 const {
-  Client, BasicClient, FileSystem, logger,
+  Client, BasicClient, FileSystem, logger, metrics,
 } = require('./lib');
 
 module.exports = {
@@ -7,4 +7,5 @@ module.exports = {
   BasicClient,
   FileSystem,
   logger,
+  metrics,
 };

--- a/lib/fs/filesystem.js
+++ b/lib/fs/filesystem.js
@@ -14,10 +14,15 @@ const OPERATION = new prom.Summary({
   registers: [metrics],
 });
 
-const CACHE = new prom.Summary({
-  name: 'sf_fs_cache',
+const CACHE_HIT = new prom.Counter({
+  name: 'sf_fs_cache_hit',
   help: 'SmartFile FS Cache',
-  labelNames: ['status'],
+  registers: [metrics],
+});
+
+const CACHE_MISS = new prom.Counter({
+  name: 'sf_fs_cache_miss',
+  help: 'SmartFile FS Cache',
   registers: [metrics],
 });
 
@@ -46,12 +51,12 @@ class FileSystem {
     // stat() calls to follow.
     const info = this.statCache[path];
     if (info) {
-      CACHE.observe({ status: 'hit' });
+      CACHE_HIT.inc();
       delete this.statCache[path];
       callback(null, info);
       return;
     }
-    CACHE.observe({ status: 'miss' });
+    CACHE_MISS.inc();
 
     operationWrapper(this.rest, 'info', [path], callback);
   }
@@ -412,4 +417,7 @@ module.exports = {
   FileSystem,
   logger,
   metrics,
+  CACHE_HIT,
+  CACHE_MISS,
+  OPERATION,
 };


### PR DESCRIPTION
Simple change I forgot. This will allow simple import like:

`const { metrics } = require('smartfile');`