### PR TITLE
Return empty array, not null for empty directory.

### DIFF
--- a/lib/fs/filesystem.js
+++ b/lib/fs/filesystem.js
@@ -345,11 +345,9 @@ class FileSystem {
         return;
       }
 
-      let names = null;
+      const names = [];
 
       if (infos) {
-        names = [];
-
         for (let i = 0; i < infos.length; i++) {
           names[i] = infos[i].name;
         }

--- a/lib/fs/filesystem.js
+++ b/lib/fs/filesystem.js
@@ -387,7 +387,7 @@ class FileSystem {
 
       // Last page, call callback.
       if (page === null) {
-        // Not that infos is null when incremental.
+        // Note that infos is null when incremental.
         end({ status: 'success' });
         callback(null, infos);
         return;

--- a/lib/rest/client.js
+++ b/lib/rest/client.js
@@ -226,7 +226,8 @@ class Client {
 
         // Call callback with a single page of data. If callback returns true,
         // cancel the listing.
-        if (callback(e, json.children) === true) {
+        const children = json.children || [];
+        if (callback(e, children) === true) {
           return;
         }
 


### PR DESCRIPTION
Was causing errors when listing an empty directory.