### PR TITLE
Rename rest client metrics.

### DIFF
--- a/lib/rest/client.js
+++ b/lib/rest/client.js
@@ -13,27 +13,27 @@ const logger = winston.createLogger({
 const metrics = new prom.Registry();
 
 const HTTP_REQUEST = new prom.Summary({
-  name: 'sf_http_request',
+  name: 'sf_rest_http_request',
   help: 'Request to SmartFile API',
   labelNames: ['method', 'statusCode', 'endpoint'],
   registers: [metrics],
 });
 
 const OPERATION = new prom.Summary({
-  name: 'sf_operation_polling',
+  name: 'sf_rest_operation_polling',
   help: 'Number of polls until completion',
   labelNames: ['endpoint', 'status'],
   registers: [metrics],
 });
 
 const CHILDREN = new prom.Summary({
-  name: 'sf_children_pages',
+  name: 'sf_rest_children_pages',
   help: 'Number of pages returned from info',
   registers: [metrics],
 });
 
 const THROTTLE = new prom.Counter({
-  name: 'sf_throttle',
+  name: 'sf_rest_throttle',
   help: 'Number of times requests were throttled',
   labelNames: ['method', 'endpoint'],
   registers: [metrics],


### PR DESCRIPTION
Make the metric names a bit clearer.