### PR TITLE
Don't poll forever.

### DIFF
--- a/lib/rest/client.js
+++ b/lib/rest/client.js
@@ -49,8 +49,9 @@ const THROTTLE = new prom.Counter({
 });
 
 // x-throttle-wait-seconds=7,
-const MIN_POLL_INTERVAL = 128;
-const MAX_POLL_INTERVAL = 30720;
+const MIN_POLL_INTERVAL = 192;
+const MAX_POLL_INTERVAL = 6144; //  About 6 seconds
+const MAX_POLL_TIMEOUT = 393216; // About 6.5 minutes
 
 
 function normPath(path) {
@@ -142,6 +143,8 @@ class Client {
   }
 
   requestOper(options, callback) {
+    const startTimeMs = Date.now();
+
     return this.requestJSON(options, (req0Error, r0, json0) => {
       if (req0Error) {
         callback(req0Error);
@@ -175,7 +178,12 @@ class Client {
           switch (json1.result.status) {
             case 'PENDING':
             case 'PROGRESS':
-              pollInterval = Math.min(pollInterval + 128, MAX_POLL_INTERVAL);
+              if (Date.now() - startTimeMs > MAX_POLL_TIMEOUT) {
+                // It's time to give up. Our client has probably moved on.
+                callback(new Error('Maximum polling interval exceeded.'));
+                return;
+              }
+              pollInterval = Math.min(pollInterval *= 2, MAX_POLL_INTERVAL);
               logger.warn(`Operation incomplete, re-polling in ${pollInterval}ms`);
 
               setTimeout(poll, pollInterval);


### PR DESCRIPTION
Celery jobs are not running in a timely manner within my local instance. If a delete is started over FTP, the FTP client eventually times out, but the FTP server, due to how polling is set up will continue polling the operation forever.

This PR puts an upper bounds on how long a job will be polled. I increased the time to the first poll (when hitting beta, about half the operations were still running on the first poll, requiring a second poll).  This should hopefully ensure the task is done by the time of first poll. I also changed backoff increase to exponential up to a max of 6 seconds.