### PR TITLE
Remove deprecated request lib.

### DIFF
--- a/lib/fs/fileproxy.js
+++ b/lib/fs/fileproxy.js
@@ -84,15 +84,16 @@ class FileProxy {
         });
 
         // Try to download the file, this will allow reading and modification.
-        this.sffs.rest.download(this.path)
-          // Download complete, because of autoClose (default: true), the
-          // stream is closed, we can reopen the path for reading.
-          .on('end', () => openFd())
-          .on('error', (downloadError) => {
-            callback(downloadError);
-          })
-          .pipe(ws);
-
+        this.sffs.rest.download(this.path, (e, res) => {
+          res
+            // Download complete, because of autoClose (default: true), the
+            // stream is closed, we can reopen the path for reading.
+            .on('end', () => openFd())
+            .on('error', (downloadError) => {
+              callback(downloadError);
+            })
+            .pipe(ws);
+        });
       // When writing, we don't need to fetch.
       } else {
         openFd();

--- a/lib/fs/fileproxy.js
+++ b/lib/fs/fileproxy.js
@@ -88,11 +88,11 @@ class FileProxy {
           res
             // Download complete, because of autoClose (default: true), the
             // stream is closed, we can reopen the path for reading.
-            .on('end', () => openFd())
             .on('error', (downloadError) => {
               callback(downloadError);
             })
-            .pipe(ws);
+            .pipe(ws)
+            .on('finish', () => openFd());
         });
       // When writing, we don't need to fetch.
       } else {

--- a/lib/fs/filesystem.js
+++ b/lib/fs/filesystem.js
@@ -185,17 +185,24 @@ class FileSystem {
     });
   }
 
-  createReadStream(path) {
-    // TODO: options is optional.
+  createReadStream(path, _options, _callback) {
     // https://nodejs.org/api/fs.html#fs_fs_createreadstream_path_options
-    return operationWrapper(this.rest, 'download', [path]);
+    // NOTE: I have to deviate from the fs module here and use a callback.
+    const callback = (typeof _options === 'function') ? _options : _callback;
+    if (!callback) {
+      logger.warn('Return value of createReadStream() is not a stream, use callback!');
+    }
+    operationWrapper(this.rest, 'download', [path], callback);
   }
 
-  // eslint-disable-next-line no-unused-vars, class-methods-use-this
-  createWriteStream(path, options) {
-    // TODO: options is optional.
+  createWriteStream(path, _options, _callback) {
     // https://nodejs.org/api/fs.html#fs_fs_createwritestream_path_options
-    return operationWrapper(this.rest, 'upload', [path]);
+    const callback = (typeof _options === 'function') ? _options : _callback;
+    return operationWrapper(this.rest, 'upload', [path], (e, json) => {
+      if (callback) {
+        callback(e, json);
+      }
+    });
   }
 
   open(path, _flags, _mode, _callback) {

--- a/lib/rest/basic.js
+++ b/lib/rest/basic.js
@@ -16,11 +16,7 @@ class BasicClient extends Client {
         throw new Error('username and password require for basic auth');
       }
 
-      options.auth = {
-        user: username,
-        pass: password,
-        sendImmediately: true,
-      };
+      options.auth = `${username}:${password}`;
     }
 
     super(options);

--- a/lib/rest/basic.js
+++ b/lib/rest/basic.js
@@ -4,20 +4,25 @@ const { Client } = require('./client');
 class BasicClient extends Client {
   constructor(opts) {
     const options = { ...opts };
+    let username;
+    let password;
 
     if (!options.auth) {
-      const username = options.username || process.env.SMARTFILE_USER;
-      const password = options.password || process.env.SMARTFILE_PASS;
+      username = options.username || options.user || process.env.SMARTFILE_USER;
+      password = options.password || options.pass || process.env.SMARTFILE_PASS;
 
       delete options.username;
       delete options.password;
 
       if (!username || !password) {
-        throw new Error('username and password require for basic auth');
+        throw new Error('username and password required for basic auth');
       }
-
-      options.auth = `${username}:${password}`;
+    } else {
+      username = options.auth.user || options.auth.username;
+      password = options.auth.pass || options.auth.password;
     }
+
+    options.auth = `${username}:${password}`;
 
     super(options);
   }

--- a/lib/rest/client.js
+++ b/lib/rest/client.js
@@ -431,7 +431,16 @@ class Client {
 
     const req = this.request(options)
       .on('response', (res) => {
-        if (callback) {
+        if (res.statusCode <= 199 || res.statusCode > 300) {
+          const resError = new Error(`${options.uri} replied with: ${res.statusCode}`);
+          resError.statusCode = res.statusCode;
+          resError.statusMessage = res.statusMessage;
+          resError.options = options;
+
+          if (callback) {
+            callback(resError, res);
+          }
+        } else if (callback) {
           callback(null, res);
         }
       })
@@ -493,19 +502,35 @@ class Client {
               buffer.push(chunk);
             })
             .on('end', () => {
-              let jsonError = null;
-              let json = null;
+              if (res.statusCode <= 199 || res.statusCode > 300) {
+                const resError = new Error(`${options.uri} replied with: ${res.statusCode}`);
+                resError.statusCode = res.statusCode;
+                resError.statusMessage = res.statusMessage;
+                resError.options = options;
 
-              try {
-                json = JSON.parse(Buffer.concat(buffer));
-              } catch (e) {
-                jsonError = e;
-              }
+                if (callback) {
+                  callback(resError, res);
+                }
+              } else {
+                let jsonError = null;
+                let json = null;
 
-              if (callback) {
-                callback(jsonError, json);
+                try {
+                  json = JSON.parse(Buffer.concat(buffer));
+                } catch (e) {
+                  jsonError = e;
+                }
+
+                if (callback) {
+                  callback(jsonError, json);
+                }
               }
             });
+        })
+        .on('error', (reqError) => {
+          if (callback) {
+            callback(reqError);
+          }
         });
     };
 

--- a/lib/rest/client.js
+++ b/lib/rest/client.js
@@ -94,7 +94,8 @@ class Client {
   }
 
   request(options, callback) {
-    let form = null;
+    let multipart = null;
+    let body = null;
     const reqUrl = new URL(this.baseUrl);
     reqUrl.pathname = options.uri;
 
@@ -122,13 +123,23 @@ class Client {
 
     if (options.json) {
       reqOptions.headers['Content-Type'] = 'application/json';
+      body = JSON.stringify(options.json);
     }
 
     if (options.form) {
-      form = new FormData();
+      reqOptions.headers['Content-Type'] = 'application/x-www-form-urlencoded';
+      const urlSearch = new URLSearchParams();
+      Object.keys(options.form).forEach((key) => {
+        urlSearch.append(key, options.form[key]);
+      });
+      body = urlSearch.toString();
+    }
 
-      Object.keys(options.form).forEach((name) => {
-        let value = options.form[name];
+    if (options.multipart) {
+      multipart = new FormData();
+
+      Object.keys(options.multipart).forEach((name) => {
+        let value = options.multipart[name];
         let opts = null;
 
         if (value.options) {
@@ -138,12 +149,12 @@ class Client {
           value = value.value;
         }
 
-        form.append(name, value, opts);
+        multipart.append(name, value, opts);
       });
 
-      const formHeaders = form.getHeaders();
-      Object.keys(formHeaders).forEach((name) => {
-        reqOptions.headers[name] = formHeaders[name];
+      const multipartHeaders = multipart.getHeaders();
+      Object.keys(multipartHeaders).forEach((name) => {
+        reqOptions.headers[name] = multipartHeaders[name];
       });
     }
 
@@ -154,12 +165,12 @@ class Client {
       req = https.request(reqUrl, reqOptions, callback);
     }
 
-    if (options.json) {
-      req.write(JSON.stringify(options.json));
+    if (body) {
+      req.write(body);
     }
 
-    if (form) {
-      form.pipe(req);
+    if (multipart) {
+      multipart.pipe(req);
     }
 
     return req;
@@ -441,7 +452,7 @@ class Client {
       const options = {
         method: 'POST',
         uri: `/api/2/path/data${encodePath(dirname)}`,
-        form: {
+        multipart: {
           file: {
             value: _s,
             options: {
@@ -508,7 +519,7 @@ class Client {
     const options = {
       method: 'POST',
       uri: '/api/2/path/oper/mkdir/',
-      json: {
+      form: {
         path: normPath(p),
       },
     };
@@ -524,7 +535,7 @@ class Client {
     const options = {
       method: 'POST',
       uri: '/api/2/path/oper/remove/',
-      json: {
+      form: {
         path: normPath(p),
       },
     };
@@ -540,7 +551,7 @@ class Client {
     const options = {
       method: 'POST',
       uri: '/api/2/path/oper/copy/',
-      json: {
+      form: {
         src: normPath(src),
         dst: normPath(dst),
       },
@@ -557,7 +568,7 @@ class Client {
     const options = {
       method: 'POST',
       uri: '/api/2/path/oper/move/',
-      json: {
+      form: {
         src: normPath(src),
         dst: normPath(dst),
       },
@@ -574,7 +585,7 @@ class Client {
     const options = {
       method: 'POST',
       uri: '/api/2/path/oper/rename/',
-      json: {
+      form: {
         src: normPath(src),
         dst: normPath(dst),
       },

--- a/lib/rest/client.js
+++ b/lib/rest/client.js
@@ -194,6 +194,10 @@ class Client {
           end({ statusCode: res.statusCode });
 
           const resError = new Error(`${options.uri} replied with: ${res.statusCode}`);
+          resError.statusCode = res.statusCode;
+          resError.statusMessage = res.statusMessage;
+          resError.options = options;
+
           callback(resError, res);
         } else {
           const buffer = [];
@@ -410,14 +414,19 @@ class Client {
       uri: `/api/2/path/data${encodePath(p)}`,
     };
 
-    this.request(options)
+    const req = this.request(options)
       .on('response', (res) => {
-        callback(null, res);
+        if (callback) {
+          callback(null, res);
+        }
       })
       .on('error', (e) => {
-        callback(e);
-      })
-      .end();
+        if (callback) {
+          callback(e);
+        }
+      });
+    req.end();
+    return req;
   }
 
   upload(p, _s, _callback) {

--- a/lib/rest/client.js
+++ b/lib/rest/client.js
@@ -1,8 +1,13 @@
 /* eslint no-underscore-dangle: ["error", { "allowAfterThis": true }] */
-const request = require('request');
+const http = require('http');
+const https = require('https');
+const FormData = require('form-data');
 const winston = require('winston');
 const pathlib = require('path');
 const prom = require('prom-client');
+
+
+const BASE_URL = 'https://app.smartfile.com/';
 
 
 const fmt = winston.format.printf(({
@@ -74,14 +79,86 @@ function encodePath(path) {
 
 class Client {
   constructor(opts) {
-    const options = { ...opts };
+    // We accept:
+    // - baseUri
+    // - auth
+    this.baseUrl = opts.baseUrl || process.env.SMARTFILE_API_URL || BASE_URL;
 
-    options.baseUrl = options.baseUrl || process.env.SMARTFILE_URL;
-    options.timeout = options.timeout || 30000;
-    options.pool = options.pool || { maxSockets: 4 };
+    const options = {
+      auth: opts.auth,
+      timeout: opts.timeout || 30000,
+      headers: opts.headers,
+    };
 
     this.options = options;
-    this.request = request.defaults(options);
+  }
+
+  request(options, callback) {
+    let form = null;
+    const reqUrl = new URL(this.baseUrl);
+    reqUrl.pathname = options.uri;
+
+    if (options.qs) {
+      Object.keys(options.qs).forEach((key) => {
+        reqUrl.searchParams.set(key, options.qs[key]);
+      });
+    }
+
+    const httpOptions = {
+      ...this.options,
+      method: options.method,
+    };
+
+    if (!httpOptions.headers) {
+      httpOptions.headers = {};
+    }
+
+    if (options.headers) {
+      // Merge in any request-specific headers.
+      Object.keys(options.headers).forEach((name) => {
+        httpOptions.headers[name] = options.headers[name];
+      });
+    }
+
+    if (options.form) {
+      form = new FormData();
+
+      Object.keys(options.form).forEach((name) => {
+        let value = options.form[name];
+        let opts = null;
+
+        if (value.options) {
+          opts = value.options;
+        }
+        if (value.value) {
+          value = value.value;
+        }
+
+        form.append(name, value, opts);
+      });
+
+      const formHeaders = form.getHeaders();
+      Object.keys(formHeaders).forEach((name) => {
+        httpOptions.headers[name] = formHeaders[name];
+      });
+    }
+
+    let req;
+    if (reqUrl.protocol === 'http:') {
+      req = http.request(reqUrl, httpOptions, callback);
+    } else {
+      req = https.request(reqUrl, httpOptions, callback);
+    }
+
+    if (options.json) {
+      req.write(JSON.stringify(options.json));
+    }
+
+    if (form) {
+      form.pipe(req);
+    }
+
+    return req;
   }
 
   requestJSON(options, callback) {
@@ -92,54 +169,56 @@ class Client {
       endpoint: options.uri,
     });
 
-    return this.request(options, (e, r, body) => {
-      if (r) {
-        end({ statusCode: r.statusCode });
-      }
+    return this.request(options)
+      .on('response', (res) => {
+        logger.debug(`${options.method}: ${options.uri}, `
+                     + `${res.statusCode}: ${res.statusMessage}`);
 
-      if (e) {
+        if (res.statusCode === 429) {
+          end({ statusCode: res.statusCode });
+
+          // Throttled.
+          let time = 1000;
+          const header = res.headers['x-throttle-wait-seconds'];
+          if (header) {
+            time = parseInt(header, 10) * 1000;
+          }
+          logger.warn(`API throttled retry in: ${time}ms`);
+          THROTTLE.inc({
+            method: options.method,
+            endpoint: options.uri,
+          });
+
+          setTimeout(this.requestJSON.bind(this), time, options, callback);
+        } else if (res.statusCode <= 199 || res.statusCode > 300) {
+          end({ statusCode: res.statusCode });
+
+          const resError = new Error(`${options.uri} replied with: ${res.statusCode}`);
+          callback(resError, res);
+        } else {
+          const buffer = [];
+          res
+            .on('data', (chunk) => {
+              buffer.push(chunk);
+            })
+            .on('end', () => {
+              end({ statusCode: res.statusCode });
+
+              let resError = null;
+              let json = null;
+              try {
+                json = JSON.parse(Buffer.concat(buffer));
+              } catch (e) {
+                resError = e;
+              }
+              callback(resError, res, json);
+            });
+        }
+      })
+      .on('error', (e) => {
         callback(e);
-        return;
-      }
-
-      logger.debug(`${options.method}: ${options.uri}, `
-                   + `${r.statusCode}: ${r.statusMessage}`);
-
-      if (r.statusCode === 429) {
-        // Throttled.
-        let time = 1000;
-        const header = r.headers['x-throttle-wait-seconds'];
-        if (header) {
-          time = parseInt(header, 10) * 1000;
-        }
-        logger.warn(`API throttled retry in: ${time}ms`);
-        THROTTLE.inc({
-          method: options.method,
-          endpoint: options.uri,
-        });
-        setTimeout(this.requestJSON.bind(this), time, options, callback);
-      } else if (r.statusCode <= 199 || r.statusCode > 300) {
-        const resError = Error(
-          `request: ${JSON.stringify(options)} returned non 2XX: `
-          + `${r.statusCode}`
-        );
-        resError.statusCode = r.statusCode;
-        resError.statusMessage = r.statusMessage;
-        resError.options = options;
-
-        callback(resError, r, body);
-      } else {
-        let json = null;
-        let resError = null;
-
-        try {
-          json = JSON.parse(body);
-        } catch (jsonError) {
-          resError = jsonError;
-        }
-        callback(resError, r, json);
-      }
-    });
+      })
+      .end();
   }
 
   requestOper(options, callback) {
@@ -312,7 +391,7 @@ class Client {
       };
       options.timeout = 30000;
 
-      getInfoPage(this, options, callback);
+      getInfoPage(this, options);
     } else {
       // Handle single-item info as a simpler case.
       this.requestJSON(options, (e, r, json) => {
@@ -331,97 +410,92 @@ class Client {
       uri: `/api/2/path/data${encodePath(p)}`,
     };
 
-    // Return the stream to caller.
-    return this.request(options)
-      .on('end', (e) => {
-        if (typeof callback === 'function') {
-          callback(e);
-        }
-      });
-  }
-
-  _uploadPost(dir, fn, s, callback) {
-    const options = {
-      method: 'POST',
-      uri: `/api/2/path/data${encodePath(dir)}`,
-      formData: {
-        file: {
-          value: s,
-          options: {
-            filename: fn,
-          },
-        },
-      },
-      // Eliminate timeout for uploads.
-      timeout: null,
-    };
-
-    this.requestJSON(options, (e, r, json) => {
-      if (callback) {
-        callback(e, json);
-      }
-    });
-  }
-
-  _uploadPut(dir, fn, callback) {
-    const options = {
-      method: 'PUT',
-      uri: `/api/2/path/data${encodePath(dir)}`,
-      headers: {
-        'X-File-Name': fn,
-        // TODO: lua requires this for now, fix that!
-        'Content-Type': 'application/octet-stream',
-      },
-      // Eliminate timeout for uploads.
-      timeout: null,
-    };
-
-    return this.request(options, (e) => {
-      if (e && callback) {
+    this.request(options)
+      .on('response', (res) => {
+        callback(null, res);
+      })
+      .on('error', (e) => {
         callback(e);
-      }
-    })
-      .on('response', (r) => {
-        let buff = '';
-
-        r
-          .on('data', (chunk) => {
-            buff += chunk.toString();
-          })
-          .on('end', () => {
-            let jsonError = null;
-            let json = null;
-
-            try {
-              json = JSON.parse(buff);
-            } catch (e) {
-              jsonError = e;
-            }
-
-            if (callback) {
-              callback(jsonError, json);
-            }
-          });
-      });
+      })
+      .end();
   }
 
-  upload(p, s, callback) {
+  upload(p, _s, _callback) {
     const dirname = pathlib.dirname(p);
     const basename = pathlib.basename(p);
 
-    if (typeof s === 'function') {
-      // NOTE: s is our callback.
-      return this._uploadPut(dirname, basename, s);
-    }
+    const post = (callback) => {
+      const options = {
+        method: 'POST',
+        uri: `/api/2/path/data${encodePath(dirname)}`,
+        form: {
+          file: {
+            value: _s,
+            options: {
+              filename: basename,
+            },
+          },
+        },
+        // Eliminate timeout for uploads.
+        timeout: null,
+      };
 
-    return this._uploadPost(dirname, basename, s, callback);
+      this.requestJSON(options, (e, r, json) => {
+        if (callback) {
+          callback(e, json);
+        }
+      });
+    };
+
+    const put = (callback) => {
+      const options = {
+        method: 'PUT',
+        uri: `/api/2/path/data${encodePath(dirname)}`,
+        headers: {
+          'X-File-Name': basename,
+          // TODO: lua requires this for now, fix that!
+          'Content-Type': 'application/octet-stream',
+        },
+        // Eliminate timeout for uploads.
+        timeout: null,
+      };
+
+      return this.request(options)
+        .on('response', (res) => {
+          const buffer = [];
+
+          res
+            .on('data', (chunk) => {
+              buffer.push(chunk);
+            })
+            .on('end', () => {
+              let jsonError = null;
+              let json = null;
+
+              try {
+                json = JSON.parse(Buffer.concat(buffer));
+              } catch (e) {
+                jsonError = e;
+              }
+
+              if (callback) {
+                callback(jsonError, json);
+              }
+            });
+        });
+    };
+
+    if (typeof _s === 'function') {
+      return put(_s);
+    }
+    return post(_callback);
   }
 
   mkdir(p, callback) {
     const options = {
       method: 'POST',
       uri: '/api/2/path/oper/mkdir/',
-      form: {
+      json: {
         path: normPath(p),
       },
     };
@@ -437,7 +511,7 @@ class Client {
     const options = {
       method: 'POST',
       uri: '/api/2/path/oper/remove/',
-      form: {
+      json: {
         path: normPath(p),
       },
     };
@@ -453,7 +527,7 @@ class Client {
     const options = {
       method: 'POST',
       uri: '/api/2/path/oper/copy/',
-      form: {
+      json: {
         src: normPath(src),
         dst: normPath(dst),
       },
@@ -470,7 +544,7 @@ class Client {
     const options = {
       method: 'POST',
       uri: '/api/2/path/oper/move/',
-      form: {
+      json: {
         src: normPath(src),
         dst: normPath(dst),
       },
@@ -487,7 +561,7 @@ class Client {
     const options = {
       method: 'POST',
       uri: '/api/2/path/oper/rename/',
-      form: {
+      json: {
         src: normPath(src),
         dst: normPath(dst),
       },

--- a/lib/rest/client.js
+++ b/lib/rest/client.js
@@ -104,20 +104,24 @@ class Client {
       });
     }
 
-    const httpOptions = {
+    const reqOptions = {
       ...this.options,
       method: options.method,
     };
 
-    if (!httpOptions.headers) {
-      httpOptions.headers = {};
+    if (!reqOptions.headers) {
+      reqOptions.headers = {};
     }
 
     if (options.headers) {
       // Merge in any request-specific headers.
       Object.keys(options.headers).forEach((name) => {
-        httpOptions.headers[name] = options.headers[name];
+        reqOptions.headers[name] = options.headers[name];
       });
+    }
+
+    if (options.json) {
+      reqOptions.headers['Content-Type'] = 'application/json';
     }
 
     if (options.form) {
@@ -139,15 +143,15 @@ class Client {
 
       const formHeaders = form.getHeaders();
       Object.keys(formHeaders).forEach((name) => {
-        httpOptions.headers[name] = formHeaders[name];
+        reqOptions.headers[name] = formHeaders[name];
       });
     }
 
     let req;
     if (reqUrl.protocol === 'http:') {
-      req = http.request(reqUrl, httpOptions, callback);
+      req = http.request(reqUrl, reqOptions, callback);
     } else {
-      req = https.request(reqUrl, httpOptions, callback);
+      req = https.request(reqUrl, reqOptions, callback);
     }
 
     if (options.json) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -343,6 +343,7 @@
       "version": "6.12.0",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.0.tgz",
       "integrity": "sha512-D6gFiFA0RRLyUbvijN74DWAjXSFxWKaWP7mldxkVhyhAV3+SWA9HEJPHQ2c9soIeTFJqcSdFDGFgdqs1iUU2Hw==",
+      "dev": true,
       "requires": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -443,19 +444,6 @@
         "es-abstract": "^1.17.0-next.1"
       }
     },
-    "asn1": {
-      "version": "0.2.4",
-      "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.4.tgz",
-      "integrity": "sha512-jxwzQpLQjSmWXgwaCZE9Nz+glAG01yF1QnWgbhGwHI5A6FRIEY6IVqtHhIepHqI7/kyEyQEagBC5mBEFlIYvdg==",
-      "requires": {
-        "safer-buffer": "~2.1.0"
-      }
-    },
-    "assert-plus": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-      "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
-    },
     "astral-regex": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-1.0.0.tgz",
@@ -475,28 +463,10 @@
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
       "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
     },
-    "aws-sign2": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
-      "integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg="
-    },
-    "aws4": {
-      "version": "1.9.1",
-      "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.9.1.tgz",
-      "integrity": "sha512-wMHVg2EOHaMRxbzgFJ9gtjOOCrI80OHLG14rxi28XwOW8ux6IiEbRCGGGqCtdAIg4FQCbW20k9RsT4y3gJlFug=="
-    },
     "balanced-match": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
       "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
-    },
-    "bcrypt-pbkdf": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
-      "integrity": "sha1-pDAdOJtqQ/m2f/PKEaP2Y342Dp4=",
-      "requires": {
-        "tweetnacl": "^0.14.3"
-      }
     },
     "binary-extensions": {
       "version": "2.0.0",
@@ -556,11 +526,6 @@
       "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
       "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
       "dev": true
-    },
-    "caseless": {
-      "version": "0.12.0",
-      "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
-      "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw="
     },
     "chalk": {
       "version": "2.4.2",
@@ -834,14 +799,6 @@
         "which": "^1.2.9"
       }
     },
-    "dashdash": {
-      "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
-      "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
-      "requires": {
-        "assert-plus": "^1.0.0"
-      }
-    },
     "debug": {
       "version": "2.6.9",
       "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
@@ -917,15 +874,6 @@
       "dev": true,
       "requires": {
         "esutils": "^2.0.2"
-      }
-    },
-    "ecc-jsbn": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
-      "integrity": "sha1-OoOpBOVDUyh4dMVkt1SThoSamMk=",
-      "requires": {
-        "jsbn": "~0.1.0",
-        "safer-buffer": "^2.1.0"
       }
     },
     "emoji-regex": {
@@ -1367,7 +1315,8 @@
     "extend": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
-      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="
+      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
+      "dev": true
     },
     "external-editor": {
       "version": "3.1.0",
@@ -1391,20 +1340,17 @@
         }
       }
     },
-    "extsprintf": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
-      "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU="
-    },
     "fast-deep-equal": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.1.tgz",
-      "integrity": "sha512-8UEa58QDLauDNfpbrX55Q9jrGHThw2ZMdOky5Gl1CDtVeJDPVrG4Jxx1N8jw2gkWaff5UUuX1KJd+9zGe2B+ZA=="
+      "integrity": "sha512-8UEa58QDLauDNfpbrX55Q9jrGHThw2ZMdOky5Gl1CDtVeJDPVrG4Jxx1N8jw2gkWaff5UUuX1KJd+9zGe2B+ZA==",
+      "dev": true
     },
     "fast-json-stable-stringify": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
-      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw=="
+      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
+      "dev": true
     },
     "fast-levenshtein": {
       "version": "2.0.6",
@@ -1617,18 +1563,13 @@
         }
       }
     },
-    "forever-agent": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
-      "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE="
-    },
     "form-data": {
-      "version": "2.3.3",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.3.tgz",
-      "integrity": "sha512-1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-3.0.0.tgz",
+      "integrity": "sha512-CKMFDglpbMi6PyN+brwB9Q/GOw0eAnsrEZDgcsH5Krhz5Od/haKHAX0NmQfha2zPPz0JpWzA7GJHGSnvCRLWsg==",
       "requires": {
         "asynckit": "^0.4.0",
-        "combined-stream": "^1.0.6",
+        "combined-stream": "^1.0.8",
         "mime-types": "^2.1.12"
       }
     },
@@ -1674,14 +1615,6 @@
       "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
       "dev": true
     },
-    "getpass": {
-      "version": "0.1.7",
-      "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
-      "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
-      "requires": {
-        "assert-plus": "^1.0.0"
-      }
-    },
     "glob": {
       "version": "7.1.6",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
@@ -1724,20 +1657,6 @@
       "resolved": "https://registry.npmjs.org/growl/-/growl-1.10.5.tgz",
       "integrity": "sha512-qBr4OuELkhPenW6goKVXiv47US3clb3/IbuWF9KNKEijAy9oeHxU9IgzjvJhHkUzhaj7rOUD7+YGWqUjLp5oSA==",
       "dev": true
-    },
-    "har-schema": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
-      "integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI="
-    },
-    "har-validator": {
-      "version": "5.1.3",
-      "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.3.tgz",
-      "integrity": "sha512-sNvOCzEQNr/qrvJgc3UG/kD4QtlHycrzwS+6mfTrrSq97BvaYcPZZI1ZSqGSPR73Cxn4LKTD4PttRwfU7jWq5g==",
-      "requires": {
-        "ajv": "^6.5.5",
-        "har-schema": "^2.0.0"
-      }
     },
     "has": {
       "version": "1.0.3",
@@ -1795,16 +1714,6 @@
       "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.0.tgz",
       "integrity": "sha512-a4u9BeERWGu/S8JiWEAQcdrg9v4QArtP9keViQjGMdff20fBdd8waotXaNmODqBe6uZ3Nafi7K/ho4gCQHV3Ig==",
       "dev": true
-    },
-    "http-signature": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
-      "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
-      "requires": {
-        "assert-plus": "^1.0.0",
-        "jsprim": "^1.2.2",
-        "sshpk": "^1.7.0"
-      }
     },
     "husky": {
       "version": "4.2.3",
@@ -2171,7 +2080,8 @@
     "is-typedarray": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
-      "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo="
+      "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
+      "dev": true
     },
     "is-windows": {
       "version": "1.0.2",
@@ -2189,11 +2099,6 @@
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
       "dev": true
-    },
-    "isstream": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
-      "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo="
     },
     "istanbul-lib-coverage": {
       "version": "3.0.0",
@@ -2388,11 +2293,6 @@
         "esprima": "^4.0.0"
       }
     },
-    "jsbn": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
-      "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM="
-    },
     "jsesc": {
       "version": "2.5.2",
       "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz",
@@ -2405,15 +2305,11 @@
       "integrity": "sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw==",
       "dev": true
     },
-    "json-schema": {
-      "version": "0.2.3",
-      "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
-      "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM="
-    },
     "json-schema-traverse": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
-      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "dev": true
     },
     "json-stable-stringify-without-jsonify": {
       "version": "1.0.1",
@@ -2424,7 +2320,8 @@
     "json-stringify-safe": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
-      "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus="
+      "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
+      "dev": true
     },
     "json5": {
       "version": "2.1.1",
@@ -2441,17 +2338,6 @@
           "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
           "dev": true
         }
-      }
-    },
-    "jsprim": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
-      "integrity": "sha1-MT5mvB5cwG5Di8G3SZwuXFastqI=",
-      "requires": {
-        "assert-plus": "1.0.0",
-        "extsprintf": "1.3.0",
-        "json-schema": "0.2.3",
-        "verror": "1.10.0"
       }
     },
     "kuler": {
@@ -3050,11 +2936,6 @@
         }
       }
     },
-    "oauth-sign": {
-      "version": "0.9.0",
-      "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.9.0.tgz",
-      "integrity": "sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ=="
-    },
     "object-inspect": {
       "version": "1.7.0",
       "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.7.0.tgz",
@@ -3256,11 +3137,6 @@
         "pify": "^2.0.0"
       }
     },
-    "performance-now": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
-      "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns="
-    },
     "picomatch": {
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.2.1.tgz",
@@ -3331,20 +3207,11 @@
       "integrity": "sha512-vGrhOavPSTz4QVNuBNdcNXePNdNMaO1xj9yBeH1ScQPjk/rhg9sSlCXPhMkFuaNNW/syTvYqsnbIJxMBfRbbag==",
       "dev": true
     },
-    "psl": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/psl/-/psl-1.7.0.tgz",
-      "integrity": "sha512-5NsSEDv8zY70ScRnOTn7bK7eanl2MvFrOrS/R6x+dBt5g1ghnj9Zv90kO8GwT8gxcu2ANyFprnFYB85IogIJOQ=="
-    },
     "punycode": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
-      "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A=="
-    },
-    "qs": {
-      "version": "6.5.2",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
-      "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA=="
+      "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
+      "dev": true
     },
     "ramda": {
       "version": "0.27.0",
@@ -3412,33 +3279,6 @@
       "dev": true,
       "requires": {
         "es6-error": "^4.0.1"
-      }
-    },
-    "request": {
-      "version": "2.88.2",
-      "resolved": "https://registry.npmjs.org/request/-/request-2.88.2.tgz",
-      "integrity": "sha512-MsvtOrfG9ZcrOwAW+Qi+F6HbD0CWXEh9ou77uOb7FM2WPhwT7smM833PzanhJLsgXjN89Ir6V2PczXNnMpwKhw==",
-      "requires": {
-        "aws-sign2": "~0.7.0",
-        "aws4": "^1.8.0",
-        "caseless": "~0.12.0",
-        "combined-stream": "~1.0.6",
-        "extend": "~3.0.2",
-        "forever-agent": "~0.6.1",
-        "form-data": "~2.3.2",
-        "har-validator": "~5.1.3",
-        "http-signature": "~1.2.0",
-        "is-typedarray": "~1.0.0",
-        "isstream": "~0.1.2",
-        "json-stringify-safe": "~5.0.1",
-        "mime-types": "~2.1.19",
-        "oauth-sign": "~0.9.0",
-        "performance-now": "^2.1.0",
-        "qs": "~6.5.2",
-        "safe-buffer": "^5.1.2",
-        "tough-cookie": "~2.5.0",
-        "tunnel-agent": "^0.6.0",
-        "uuid": "^3.3.2"
       }
     },
     "require-directory": {
@@ -3512,7 +3352,8 @@
     "safer-buffer": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
-      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "dev": true
     },
     "semver": {
       "version": "5.7.1",
@@ -3685,22 +3526,6 @@
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
       "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
       "dev": true
-    },
-    "sshpk": {
-      "version": "1.16.1",
-      "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.16.1.tgz",
-      "integrity": "sha512-HXXqVUq7+pcKeLqqZj6mHFUMvXtOJt1uoUx09pFW6011inTMxqI8BA8PM95myrIyyKwdnzjdFjLiE6KBPVtJIg==",
-      "requires": {
-        "asn1": "~0.2.3",
-        "assert-plus": "^1.0.0",
-        "bcrypt-pbkdf": "^1.0.0",
-        "dashdash": "^1.12.0",
-        "ecc-jsbn": "~0.1.1",
-        "getpass": "^0.1.1",
-        "jsbn": "~0.1.0",
-        "safer-buffer": "^2.0.2",
-        "tweetnacl": "~0.14.0"
-      }
     },
     "stack-trace": {
       "version": "0.0.10",
@@ -3901,15 +3726,6 @@
         "is-number": "^7.0.0"
       }
     },
-    "tough-cookie": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.5.0.tgz",
-      "integrity": "sha512-nlLsUzgm1kfLXSXfRZMc1KLAugd4hqJHDTvc2hDIwS3mZAfMEuMbc03SujMF+GEcpaX/qboeycw6iO8JwVv2+g==",
-      "requires": {
-        "psl": "^1.1.28",
-        "punycode": "^2.1.1"
-      }
-    },
     "triple-beam": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/triple-beam/-/triple-beam-1.3.0.tgz",
@@ -3920,19 +3736,6 @@
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.11.1.tgz",
       "integrity": "sha512-aZW88SY8kQbU7gpV19lN24LtXh/yD4ZZg6qieAJDDg+YBsJcSmLGK9QpnUjAKVG/xefmvJGd1WUmfpT/g6AJGA==",
       "dev": true
-    },
-    "tunnel-agent": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
-      "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
-      "requires": {
-        "safe-buffer": "^5.0.1"
-      }
-    },
-    "tweetnacl": {
-      "version": "0.14.5",
-      "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
-      "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q="
     },
     "type-check": {
       "version": "0.3.2",
@@ -3962,6 +3765,7 @@
       "version": "4.2.2",
       "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.2.2.tgz",
       "integrity": "sha512-KY9Frmirql91X2Qgjry0Wd4Y+YTdrdZheS8TFwvkbLWf/G5KNJDCh6pKL5OZctEW4+0Baa5idK2ZQuELRwPznQ==",
+      "dev": true,
       "requires": {
         "punycode": "^2.1.0"
       }
@@ -3974,7 +3778,8 @@
     "uuid": {
       "version": "3.4.0",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
-      "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A=="
+      "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
+      "dev": true
     },
     "v8-compile-cache": {
       "version": "2.1.0",
@@ -3990,16 +3795,6 @@
       "requires": {
         "spdx-correct": "^3.0.0",
         "spdx-expression-parse": "^3.0.0"
-      }
-    },
-    "verror": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
-      "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
-      "requires": {
-        "assert-plus": "^1.0.0",
-        "core-util-is": "1.0.2",
-        "extsprintf": "^1.2.0"
       }
     },
     "which": {

--- a/package.json
+++ b/package.json
@@ -4,8 +4,8 @@
   "description": "SmartFile API client for node.js.",
   "main": "index.js",
   "scripts": {
-    "test": "mocha --recursive --full-trace tests/**/*",
-    "debug": "mocha inspect --recursive --full-trace tests/**/*",
+    "test": "mocha --full-trace tests/test_rest.js",
+    "debug": "mocha inspect --full-trace tests/test_rest.js",
     "coverage": "nyc npm run test",
     "lint": "eslint --format node_modules/eslint-friendly-formatter ."
   },
@@ -30,9 +30,9 @@
   "author": "SmartFile",
   "license": "MIT",
   "dependencies": {
+    "form-data": "^3.0.0",
     "memory-streams": "^0.1.3",
     "prom-client": "^12.0.0",
-    "request": "^2.83.0",
     "tmp": "^0.1.0",
     "winston": "^3.2.1"
   },

--- a/package.json
+++ b/package.json
@@ -4,8 +4,8 @@
   "description": "SmartFile API client for node.js.",
   "main": "index.js",
   "scripts": {
-    "test": "mocha --full-trace tests/test_rest.js",
-    "debug": "mocha inspect --full-trace tests/test_rest.js",
+    "test": "mocha --recursive --full-trace tests/**/test_*",
+    "debug": "mocha inspect --recursive --full-trace tests/**/test_*",
     "coverage": "nyc npm run test",
     "lint": "eslint --format node_modules/eslint-friendly-formatter ."
   },

--- a/tests/test_auth.js
+++ b/tests/test_auth.js
@@ -1,0 +1,96 @@
+const nock = require('nock');
+const assert = require('assert');
+const { morph } = require('mock-env');
+const { logger, BasicClient } = require('../lib');
+const { assertNoError } = require('./utils');
+
+
+const API_URL = 'http://fakeapi.foo/';
+
+logger.silent = true;
+
+
+describe('SmartFile Basic API client', () => {
+  it('can read config from env', (done) => {
+    /*
+    This test instantiates a client without any options.
+
+    It then ensures the client has picked up configuration options from the
+    environment. However, we use mock-env.morph to only temporarily set
+    "environment" variables for this test.
+    */
+
+    let client;
+
+    morph(() => {
+      client = new BasicClient();
+    }, {
+      SMARTFILE_API_URL: API_URL,
+      SMARTFILE_USER: 'foobar',
+      SMARTFILE_PASS: 'baz',
+    });
+
+    assert(client.baseUrl === API_URL);
+    assert(client.options.auth === 'foobar:baz');
+
+    done();
+  });
+
+  it('can authenticate', (done) => {
+    const api = nock(API_URL)
+      .get('/api/2/path/info/foobar')
+      .basicAuth({
+        user: 'username',
+        pass: 'password',
+      })
+      .reply(200, '{ "name": "foobar", "isdir": true, "isfile": false }');
+
+    const client = new BasicClient({
+      username: 'username',
+      password: 'password',
+      baseUrl: API_URL,
+    });
+
+    client.info('/foobar', (e) => {
+      assertNoError(e);
+      assert(api.isDone());
+      done();
+    });
+  });
+
+  it('accepts credentials in multiple forms', (done) => {
+    const credentials = [
+      {
+        username: 'username',
+        password: 'password',
+        baseUrl: API_URL,
+      },
+      {
+        user: 'username',
+        pass: 'password',
+        baseUrl: API_URL,
+      },
+      {
+        auth: {
+          username: 'username',
+          password: 'password',
+        },
+        baseUrl: API_URL,
+      },
+      {
+        auth: {
+          user: 'username',
+          pass: 'password',
+        },
+        baseUrl: API_URL,
+      },
+    ];
+
+    let client;
+    credentials.forEach((opts) => {
+      client = new BasicClient(opts);
+      assert(client.options.auth === 'username:password');
+    });
+    done();
+  });
+});

--- a/tests/test_auth.js
+++ b/tests/test_auth.js
@@ -11,7 +11,7 @@ logger.silent = true;
 
 
 describe('SmartFile Basic API client', () => {
-  it('can read config from env', (done) => {
+  it('can read config from env', () => {
     /*
     This test instantiates a client without any options.
 
@@ -32,8 +32,6 @@ describe('SmartFile Basic API client', () => {
 
     assert(client.baseUrl === API_URL);
     assert(client.options.auth === 'foobar:baz');
-
-    done();
   });
 
   it('can authenticate', (done) => {
@@ -58,7 +56,7 @@ describe('SmartFile Basic API client', () => {
     });
   });
 
-  it('accepts credentials in multiple forms', (done) => {
+  it('accepts credentials in multiple forms', () => {
     const credentials = [
       {
         username: 'username',
@@ -91,6 +89,5 @@ describe('SmartFile Basic API client', () => {
       client = new BasicClient(opts);
       assert(client.options.auth === 'username:password');
     });
-    done();
   });
 });

--- a/tests/test_fs.js
+++ b/tests/test_fs.js
@@ -2,7 +2,7 @@ const nock = require('nock');
 const assert = require('assert');
 const smartfile = require('../lib');
 const { CACHE_HIT } = require('../lib/fs/filesystem');
-const { assertNoError } = require('./utils');
+const { assertNoError, assertError } = require('./utils');
 
 
 const API_URL = 'http://fakeapi.foo/';
@@ -223,6 +223,20 @@ describe('File System Abstraction', () => {
     const s = sffs.createWriteStream('/foobar', (e, json) => {
       assertNoError(e);
       assert(json.name === 'foobar');
+      assert(api.isDone());
+      done();
+    });
+    s.write('BODY');
+    s.end();
+  });
+
+  it('reports errors correctly during upload', (done) => {
+    const api = server
+      .put('/api/2/path/data/')
+      .reply(500, 'Internal server error');
+
+    const s = sffs.createWriteStream('/foobar', (e) => {
+      assertError(e, 500);
       assert(api.isDone());
       done();
     });

--- a/tests/test_fs.js
+++ b/tests/test_fs.js
@@ -1,19 +1,12 @@
 const nock = require('nock');
 const assert = require('assert');
-
 const smartfile = require('../lib');
 const { CACHE_HIT } = require('../lib/fs/filesystem');
+const { assertNoError } = require('./utils');
 
 
 const API_URL = 'http://fakeapi.foo/';
 
-
-function assertNoError(e) {
-  // Assertion to ensure that error is omitted inside a callback.
-  if (e) {
-    throw e;
-  }
-}
 
 function assertMetric(metric, value) {
   // Asserts that a paritcular metric has the desired value.

--- a/tests/test_rest.js
+++ b/tests/test_rest.js
@@ -1,26 +1,14 @@
 const nock = require('nock');
 const assert = require('assert');
-const { morph } = require('mock-env');
 const streams = require('memory-streams');
+const { logger, Client } = require('../lib');
+const { normPath, encodePath } = require('../lib/rest/client');
+const { assertNoError } = require('./utils');
 
-const {
-  logger, Client, BasicClient,
-} = require('../lib');
-const {
-  normPath, encodePath,
-} = require('../lib/rest/client');
 
 const API_URL = 'http://fakeapi.foo/';
 
 logger.silent = true;
-
-
-function assertNoError(e) {
-  // Assertion to ensure that error is omitted inside a callback.
-  if (e) {
-    throw e;
-  }
-}
 
 
 describe('REST API client', () => {
@@ -32,53 +20,6 @@ describe('REST API client', () => {
     assert(encodePath('/foo#bar') === '/foo%23bar');
     assert(encodePath('/foo%23bar') === '/foo%2523bar');
     done();
-  });
-
-  it('can read config from env', (done) => {
-    /*
-    This test instantiates a client without any options.
-
-    It then ensures the client has picked up configuration options from the
-    environment. However, we use mock-env.morph to only temporarily set
-    "environment" variables for this test.
-    */
-
-    let client;
-
-    morph(() => {
-      client = new BasicClient();
-    }, {
-      SMARTFILE_API_URL: API_URL,
-      SMARTFILE_USER: 'foobar',
-      SMARTFILE_PASS: 'baz',
-    });
-
-    assert(client.baseUrl === API_URL);
-    assert(client.options.auth === 'foobar:baz');
-
-    done();
-  });
-
-  it('can authenticate', (done) => {
-    const api = nock(API_URL)
-      .get('/api/2/path/info/foobar')
-      .basicAuth({
-        user: 'username',
-        pass: 'password',
-      })
-      .reply(200, '{ "name": "foobar", "isdir": true, "isfile": false }');
-
-    const client = new BasicClient({
-      username: 'username',
-      password: 'password',
-      baseUrl: API_URL,
-    });
-
-    client.info('/foobar', (e) => {
-      assertNoError(e);
-      assert(api.isDone());
-      done();
-    });
   });
 
   it('sends a custom header', (done) => {

--- a/tests/test_rest.js
+++ b/tests/test_rest.js
@@ -173,9 +173,13 @@ describe('REST API client', () => {
       .get('/api/2/path/data/foobar')
       .reply(200, 'BODY');
 
-    client.download('/foobar', (e, r) => {
-      r.pipe(ws);
-      done();
+    client.download('/foobar', (e, res) => {
+      res
+        .pipe(ws)
+        .on('finish', () => {
+          assert(ws.toString() === 'BODY');
+          done();
+        });
     });
   });
 

--- a/tests/test_rest.js
+++ b/tests/test_rest.js
@@ -48,14 +48,13 @@ describe('REST API client', () => {
     morph(() => {
       client = new BasicClient();
     }, {
-      SMARTFILE_URL: API_URL,
+      SMARTFILE_API_URL: API_URL,
       SMARTFILE_USER: 'foobar',
       SMARTFILE_PASS: 'baz',
     });
 
-    assert(client.options.baseUrl === API_URL);
-    assert(client.options.auth.user === 'foobar');
-    assert(client.options.auth.pass === 'baz');
+    assert(client.baseUrl === API_URL);
+    assert(client.options.auth === 'foobar:baz');
 
     done();
   });
@@ -174,14 +173,13 @@ describe('REST API client', () => {
       .get('/api/2/path/data/foobar')
       .reply(200, 'BODY');
 
-    client.download('/foobar', () => {
-      assert(ws.toString() === 'BODY');
+    client.download('/foobar', (e, r) => {
+      r.pipe(ws);
       done();
-    })
-      .pipe(ws);
+    });
   });
 
-  it('can upload a stream', (done) => {
+  it('can upload a stream as multipart/form', (done) => {
     /* This test passes a stream to upload()
 
     This results in a regular multi-part POST.
@@ -201,7 +199,7 @@ describe('REST API client', () => {
     });
   });
 
-  it('can upload a stream', (done) => {
+  it('can upload a stream via pipe', (done) => {
     /* This test pipes a stream to upload().
 
     By omitting a readableStream parameter, a writableStream is returned.

--- a/tests/utils.js
+++ b/tests/utils.js
@@ -1,0 +1,11 @@
+
+function assertNoError(e) {
+  // Assertion to ensure that error is omitted inside a callback.
+  if (e) {
+    throw e;
+  }
+}
+
+module.exports = {
+  assertNoError,
+};

--- a/tests/utils.js
+++ b/tests/utils.js
@@ -6,6 +6,13 @@ function assertNoError(e) {
   }
 }
 
+function assertError(e, statusCode) {
+  if (!e || (e && statusCode && e.statusCode !== statusCode)) {
+    throw e;
+  }
+}
+
 module.exports = {
   assertNoError,
+  assertError,
 };


### PR DESCRIPTION
The library I was using for HTTP is deprecated. Node has http / https libraries included. They are lower-level and afford more control over the requests (which is nice because I am unable to do some things I would like in dependent projects).

This PR removes the request library and replaces it's functionality with a new function `request()` that handles all the HTTP particulars.