### PR TITLE
Add more caching.

### DIFF
--- a/lib/fs/fileproxy.js
+++ b/lib/fs/fileproxy.js
@@ -163,15 +163,9 @@ class FileProxy {
         autoClose: false,
       });
 
-      this.sffs.rest.upload(this.path, rs, (e) => {
+      this.sffs.rest.upload(this.path, rs, (e, json) => {
         cleanup();
-
-        if (e) {
-          callback(e);
-          return;
-        }
-
-        callback(null);
+        callback(e, json);
       });
     } else {
       cleanup();

--- a/lib/fs/filesystem.js
+++ b/lib/fs/filesystem.js
@@ -48,9 +48,15 @@ class FileSystem {
     this.statCache = {};
   }
 
-  _removeCache(path) {
+  _maybeDelCache(path, level) {
+    if (level > this.cacheLevel) {
+      logger.debug(`Leaving ${path} in cache`);
+      return [];
+    }
+
     let recurse = true;
     const obj = this.statCache[path];
+    const removed = [obj];
 
     if (obj && obj.isfile) {
       recurse = false;
@@ -66,9 +72,32 @@ class FileSystem {
       Object.keys(this.statCache).forEach((key) => {
         if (key.startsWith(path)) {
           logger.debug(`Recursively removing path "${key}" from cache.`);
-          delete this.statsCache[key];
+          removed.push(this.statCache[key]);
+          delete this.statCache[key];
         }
       });
+    }
+
+    return removed;
+  }
+
+  _maybeAddCache(obj, level) {
+    if (!obj) {
+      return;
+    }
+    if (level < this.cacheLevel) {
+      logger.debug(`Opting NOT to cache ${obj.path}`);
+      return;
+    }
+
+    logger.debug(`Adding "${obj.path}" to cache.`);
+    this.statCache[obj.path] = obj;
+  }
+
+  _maybeClearCache(level) {
+    if (level >= this.cacheLevel) {
+      logger.debug('Clearing cache');
+      this.statCache = {};
     }
   }
 
@@ -79,9 +108,7 @@ class FileSystem {
     if (info) {
       logger.debug(`Cache HIT for "${path}"`);
       CACHE_HIT.inc();
-      if (this.cacheLevel < 2) {
-        this._removeCache(path);
-      }
+      this._maybeDelCache(path, 2);
       callback(null, info);
       return;
     }
@@ -94,10 +121,7 @@ class FileSystem {
         return;
       }
 
-      if (this.cacheLevel > 1) {
-        logger.debug(`Adding "${path}" to cache.`);
-        this.statCache[path] = json;
-      }
+      this._maybeAddCache(json, 1);
       callback(null, json);
     });
   }
@@ -110,7 +134,7 @@ class FileSystem {
     return operationWrapper(this.rest, 'delete', [path], (e, json) => {
       if (e && e.statusCode === 404
         && e.options.uri === '/api/2/path/oper/remove/') {
-        this._removeCache(path);
+        this._maybeDelCache(path, 0);
         // Mask out the error, and forge a fake response.
         callback(null, {
           result: {
@@ -119,7 +143,7 @@ class FileSystem {
         });
       } else {
         if (!e) {
-          this._removeCache(path);
+          this._maybeDelCache(path, 0);
         }
         callback(e, json);
       }
@@ -131,7 +155,13 @@ class FileSystem {
   }
 
   mkdir(path, callback) {
-    return operationWrapper(this.rest, 'mkdir', [path], callback);
+    return operationWrapper(this.rest, 'mkdir', [path], (e, json) => {
+      if (!e) {
+        this._maybeAddCache(json, 2);
+      }
+
+      callback(e, json);
+    });
   }
 
   copy(src, dst, callback) {
@@ -199,6 +229,10 @@ class FileSystem {
     // https://nodejs.org/api/fs.html#fs_fs_createwritestream_path_options
     const callback = (typeof _options === 'function') ? _options : _callback;
     return operationWrapper(this.rest, 'upload', [path], (e, json) => {
+      if (!e) {
+        this._maybeAddCache(json, 2);
+      }
+
       if (callback) {
         callback(e, json);
       }
@@ -264,7 +298,13 @@ class FileSystem {
       return;
     }
 
-    file.close(callback);
+    file.close((e, json) => {
+      if (!e) {
+        this._maybeAddCache(json, 2);
+      }
+
+      callback(e, json);
+    });
     end({ status: 'success' });
   }
 
@@ -387,9 +427,10 @@ class FileSystem {
 
           pos += bytesWritten;
           if (pos === buffer.byteLength) {
-            this.close(fd, (closeError) => {
+            this.close(fd, (closeError, json) => {
               end({ status: 'success' });
-              callback(closeError);
+              this._maybeAddCache(json, 2);
+              callback(closeError, json);
             });
             return;
           }
@@ -440,10 +481,7 @@ class FileSystem {
 
     // Clear cache, only meant to be used for stat() calls following a
     // readdir().
-    if (this.cacheLevel < 2) {
-      logger.debug('Clearing cache');
-      this.statCache = {};
-    }
+    this._maybeClearCache(2);
 
     // Make API call.
     this.rest.info(path, (e, page, json) => {
@@ -459,8 +497,7 @@ class FileSystem {
           // eslint-disable-next-line no-param-reassign
           delete json[key];
         });
-        logger.debug(`Adding "${path}" to cache.`);
-        this.statCache[path] = json;
+        this._maybeAddCache(json, 1);
       }
 
       // Last page, call callback.
@@ -483,10 +520,7 @@ class FileSystem {
 
         // Cache stat information, most times stat() calls for everything we
         // list are imminent.
-        if (this.cacheLevel > 0) {
-          logger.debug(`Adding "${page[i].path}" to cache.`);
-          this.statCache[page[i].path] = page[i];
-        }
+        this._maybeAddCache(page[i], 1);
       }
     }, args);
   }

--- a/lib/fs/filesystem.js
+++ b/lib/fs/filesystem.js
@@ -165,6 +165,9 @@ class FileSystem {
   }
 
   copy(src, dst, callback) {
+    // Because this is an operation, the JSON indicates the status of
+    // the operation, but does not return the dst object. Therefore
+    // we cannot "prime" the cache.
     return operationWrapper(this.rest, 'copy', [src, dst], callback);
   }
 
@@ -177,15 +180,10 @@ class FileSystem {
   }
 
   move(src, dst, callback) {
-    return operationWrapper(this.rest, 'move', [src, dst], (e, json) => {
-      if (e) {
-        callback(e);
-        return;
-      }
-
-      this._removeCache(src);
-      callback(null, json);
-    });
+    // Because this is an operation, the JSON indicates the status of
+    // the operation, but does not return the dst object. Therefore
+    // we cannot "prime" the cache.
+    return operationWrapper(this.rest, 'move', [src, dst], callback);
   }
 
   rename(src, dst, callback) {
@@ -195,7 +193,8 @@ class FileSystem {
         return;
       }
 
-      this._removeCache(src);
+      this._maybeAddCache(json, 2);
+      this._maybeDelCache(src, 0);
       callback(null, json);
     });
   }
@@ -491,13 +490,15 @@ class FileSystem {
         return;
       }
 
-      if (json && this.cacheLevel > 1) {
+      if (json) {
+        // Don't modify the original.
+        const jsonClone = JSON.parse(JSON.stringify(json));
         // Remove some stuff that we don't want in cache.
         ['children', 'total', 'pages', 'page', 'per_page'].forEach((key) => {
           // eslint-disable-next-line no-param-reassign
-          delete json[key];
+          delete jsonClone[key];
         });
-        this._maybeAddCache(json, 1);
+        this._maybeAddCache(jsonClone, 1);
       }
 
       // Last page, call callback.
@@ -508,11 +509,7 @@ class FileSystem {
         return;
       }
 
-      if (options.incremental) {
-        callback(null, page);
-      }
-
-      // Buffer page of results.
+      // Cache page of results.
       for (let i = 0; i < page.length; i++) {
         if (!options.incremental) {
           infos.push(page[i]);
@@ -521,6 +518,10 @@ class FileSystem {
         // Cache stat information, most times stat() calls for everything we
         // list are imminent.
         this._maybeAddCache(page[i], 1);
+      }
+
+      if (options.incremental) {
+        callback(null, page);
       }
     }, args);
   }

--- a/tests/test_rest.js
+++ b/tests/test_rest.js
@@ -57,11 +57,10 @@ describe('REST API client', () => {
     done();
   });
 
-  /*
-  afterEach('', function(done) {
+  afterEach('', (done) => {
+    nock.cleanAll();
     done();
   });
-  */
 
   it('can ping api', (done) => {
     /*


### PR DESCRIPTION
I modified all `filesystem` operations that receive file objects from the API so that they add these objects to cache. I added assertions in the unit tests to ensure objects exist in cache. I had to modify the mock JSON to include `name` and `path` attributes where appropriate (as these are necessary for caching).