### PR TITLE
Cache

### DIFF
--- a/demo.js
+++ b/demo.js
@@ -6,9 +6,9 @@ process.env.NODE_TLS_REJECT_UNAUTHORIZED = '0';
 
 
 const rest = new BasicClient({
-    baseUrl: 'https://test.dev.smartfile.com/',
-    username: 'administrator',
-    password: 'password',
+  baseUrl: 'https://app.smartfile.com/',
+  username: 'username',
+  password: 'password',
 });
 const sffs = new FileSystem(rest);
 

--- a/demo.js
+++ b/demo.js
@@ -1,0 +1,18 @@
+const fs = require('fs');
+const { BasicClient, FileSystem } = require('./lib');
+
+
+process.env.NODE_TLS_REJECT_UNAUTHORIZED = '0';
+
+
+const rest = new BasicClient({
+    baseUrl: 'https://test.dev.smartfile.com/',
+    username: 'administrator',
+    password: 'password',
+});
+const sffs = new FileSystem(rest);
+
+const rs = fs.createReadStream('test.js');
+const ws = sffs.createWriteStream('/test.js');
+
+rs.pipe(ws);

--- a/lib/fs/filesystem.js
+++ b/lib/fs/filesystem.js
@@ -48,9 +48,8 @@ class FileSystem {
     this.statCache = {};
   }
 
-  _maybeDelCache(path, level) {
-    if (level > this.cacheLevel) {
-      logger.debug(`Leaving ${path} in cache`);
+  _delCache(path, ...levels) {
+    if (levels.indexOf(this.cacheLevel) === -1) {
       return [];
     }
 
@@ -81,12 +80,11 @@ class FileSystem {
     return removed;
   }
 
-  _maybeAddCache(obj, level) {
-    if (!obj) {
+  _addCache(obj, ...levels) {
+    if (levels.indexOf(this.cacheLevel) === -1) {
       return;
     }
-    if (level > this.cacheLevel) {
-      logger.debug(`Opting NOT to cache ${obj.path}`);
+    if (!obj) {
       return;
     }
 
@@ -94,11 +92,12 @@ class FileSystem {
     this.statCache[obj.path] = obj;
   }
 
-  _maybeClearCache(level) {
-    if (level > this.cacheLevel) {
-      logger.debug('Clearing cache');
-      this.statCache = {};
+  _clearCache(...levels) {
+    if (levels.indexOf(this.cacheLevel) === -1) {
+      return;
     }
+    logger.debug('Clearing cache');
+    this.statCache = {};
   }
 
   stat(path, callback) {
@@ -108,7 +107,7 @@ class FileSystem {
     if (info) {
       logger.debug(`Cache HIT for "${path}"`);
       CACHE_HIT.inc();
-      this._maybeDelCache(path, 1);
+      this._delCache(path, 0, 1);
       callback(null, info);
       return;
     }
@@ -121,7 +120,7 @@ class FileSystem {
         return;
       }
 
-      this._maybeAddCache(json, 1);
+      this._addCache(json, 2);
       callback(null, json);
     });
   }
@@ -134,7 +133,7 @@ class FileSystem {
     return operationWrapper(this.rest, 'delete', [path], (e, json) => {
       if (e && e.statusCode === 404
         && e.options.uri === '/api/2/path/oper/remove/') {
-        this._maybeDelCache(path, Number.MAX_SAFE_INTEGER);
+        this._delCache(path, 0, 1, 2);
         // Mask out the error, and forge a fake response.
         callback(null, {
           result: {
@@ -143,7 +142,7 @@ class FileSystem {
         });
       } else {
         if (!e) {
-          this._maybeDelCache(path, Number.MAX_SAFE_INTEGER);
+          this._delCache(path, 0, 1, 2);
         }
         callback(e, json);
       }
@@ -157,7 +156,7 @@ class FileSystem {
   mkdir(path, callback) {
     return operationWrapper(this.rest, 'mkdir', [path], (e, json) => {
       if (!e) {
-        this._maybeAddCache(json, 2);
+        this._addCache(json, 2);
       }
 
       callback(e, json);
@@ -193,8 +192,9 @@ class FileSystem {
         return;
       }
 
-      this._maybeAddCache(json, 2);
-      this._maybeDelCache(src, Number.MAX_SAFE_INTEGER);
+      // Cache the item at cache level 2.
+      this._addCache(json, 2);
+      this._delCache(src, 0, 1, 2);
       callback(null, json);
     });
   }
@@ -229,7 +229,7 @@ class FileSystem {
     const callback = (typeof _options === 'function') ? _options : _callback;
     return operationWrapper(this.rest, 'upload', [path], (e, json) => {
       if (!e) {
-        this._maybeAddCache(json, 1);
+        this._addCache(json, 2);
       }
 
       if (callback) {
@@ -299,7 +299,7 @@ class FileSystem {
 
     file.close((e, json) => {
       if (!e) {
-        this._maybeAddCache(json, 1);
+        this._addCache(json, 2);
       }
 
       callback(e, json);
@@ -428,7 +428,7 @@ class FileSystem {
           if (pos === buffer.byteLength) {
             this.close(fd, (closeError, json) => {
               end({ status: 'success' });
-              this._maybeAddCache(json, 2);
+              this._addCache(json, 2);
               callback(closeError, json);
             });
             return;
@@ -478,9 +478,7 @@ class FileSystem {
     // Buffer when not incremental.
     const infos = options.incremental ? null : [];
 
-    // Clear cache, only meant to be used for stat() calls following a
-    // readdir().
-    this._maybeClearCache(2);
+    this._clearCache(0, 1);
 
     // Make API call.
     this.rest.info(path, (e, page, json) => {
@@ -498,7 +496,7 @@ class FileSystem {
           // eslint-disable-next-line no-param-reassign
           delete jsonClone[key];
         });
-        this._maybeAddCache(jsonClone, 1);
+        this._addCache(jsonClone, 1, 2);
       }
 
       // Last page, call callback.
@@ -515,9 +513,7 @@ class FileSystem {
           infos.push(page[i]);
         }
 
-        // Cache stat information, most times stat() calls for everything we
-        // list are imminent.
-        this._maybeAddCache(page[i], 1);
+        this._addCache(page[i], 1, 2);
       }
 
       if (options.incremental) {

--- a/lib/fs/filesystem.js
+++ b/lib/fs/filesystem.js
@@ -229,7 +229,7 @@ class FileSystem {
     const callback = (typeof _options === 'function') ? _options : _callback;
     return operationWrapper(this.rest, 'upload', [path], (e, json) => {
       if (!e) {
-        this._maybeAddCache(json, 2);
+        this._maybeAddCache(json, 1);
       }
 
       if (callback) {
@@ -299,7 +299,7 @@ class FileSystem {
 
     file.close((e, json) => {
       if (!e) {
-        this._maybeAddCache(json, 2);
+        this._maybeAddCache(json, 1);
       }
 
       callback(e, json);

--- a/lib/fs/filesystem.js
+++ b/lib/fs/filesystem.js
@@ -85,7 +85,7 @@ class FileSystem {
     if (!obj) {
       return;
     }
-    if (level < this.cacheLevel) {
+    if (level > this.cacheLevel) {
       logger.debug(`Opting NOT to cache ${obj.path}`);
       return;
     }
@@ -95,7 +95,7 @@ class FileSystem {
   }
 
   _maybeClearCache(level) {
-    if (level >= this.cacheLevel) {
+    if (level > this.cacheLevel) {
       logger.debug('Clearing cache');
       this.statCache = {};
     }

--- a/lib/fs/filesystem.js
+++ b/lib/fs/filesystem.js
@@ -228,7 +228,7 @@ class FileSystem {
     // https://nodejs.org/api/fs.html#fs_fs_createwritestream_path_options
     const callback = (typeof _options === 'function') ? _options : _callback;
     return operationWrapper(this.rest, 'upload', [path], (e, json) => {
-      if (!e) {
+      if (!e && json) {
         this._addCache(json, 2);
       }
 

--- a/lib/fs/filesystem.js
+++ b/lib/fs/filesystem.js
@@ -108,7 +108,7 @@ class FileSystem {
     if (info) {
       logger.debug(`Cache HIT for "${path}"`);
       CACHE_HIT.inc();
-      this._maybeDelCache(path, 2);
+      this._maybeDelCache(path, 1);
       callback(null, info);
       return;
     }
@@ -134,7 +134,7 @@ class FileSystem {
     return operationWrapper(this.rest, 'delete', [path], (e, json) => {
       if (e && e.statusCode === 404
         && e.options.uri === '/api/2/path/oper/remove/') {
-        this._maybeDelCache(path, 0);
+        this._maybeDelCache(path, Number.MAX_SAFE_INTEGER);
         // Mask out the error, and forge a fake response.
         callback(null, {
           result: {
@@ -143,7 +143,7 @@ class FileSystem {
         });
       } else {
         if (!e) {
-          this._maybeDelCache(path, 0);
+          this._maybeDelCache(path, Number.MAX_SAFE_INTEGER);
         }
         callback(e, json);
       }
@@ -194,7 +194,7 @@ class FileSystem {
       }
 
       this._maybeAddCache(json, 2);
-      this._maybeDelCache(src, 0);
+      this._maybeDelCache(src, Number.MAX_SAFE_INTEGER);
       callback(null, json);
     });
   }

--- a/tests/test_fs.js
+++ b/tests/test_fs.js
@@ -39,7 +39,7 @@ describe('File System Abstraction', () => {
   afterEach('', (done) => {
     nock.cleanAll();
     // eslint-disable-next-line no-underscore-dangle
-    sffs._maybeClearCache(0);
+    sffs._clearCache(0, 1, 2);
     done();
   });
 
@@ -98,7 +98,7 @@ describe('File System Abstraction', () => {
         }
 
         sffs.close(fd, (closeError) => {
-          assert(sffs.statCache['/foobar']);
+          assert(!sffs.statCache['/foobar']);
           assertNoError(closeError);
           assert(api.isDone());
           done();
@@ -115,7 +115,7 @@ describe('File System Abstraction', () => {
     const buff = Buffer.from('BODY');
 
     sffs.writeFile('/foobar', buff, (e) => {
-      assert(sffs.statCache['/foobar']);
+      assert(!sffs.statCache['/foobar']);
       assert(api.isDone());
       assertNoError(e);
       done();
@@ -240,7 +240,7 @@ describe('File System Abstraction', () => {
       .reply(200, '{ "name": "foobar", "path": "/foobar" }');
 
     const s = sffs.createWriteStream('/foobar', (e, json) => {
-      assert(sffs.statCache['/foobar']);
+      assert(!sffs.statCache['/foobar']);
       assertNoError(e);
       assert(json.name === 'foobar');
       assert(api.isDone());


### PR DESCRIPTION
I wanted to consolidate the caching logic into a set of functions, but I had a lot of trouble wrapping my head around the first couple iterations (using lte, gt etc). The latest version is much more sensible and allows you to call the functions like: `_addCache(path, 1, 2)` where 1 and 2 represent the desired `cacheLevel`.  As in, you only want to cache the item for level 1 and 2 (the highest). Now I think I have this all set up how I want it.