### PR TITLE
Allow overriding HTTP options (including headers).

### DIFF
--- a/lib/fs/filesystem.js
+++ b/lib/fs/filesystem.js
@@ -471,8 +471,11 @@ class FileSystem {
     };
 
     // API arguments.
-    const args = {
-      children: true,
+    const reqOptions = {
+      qs: {
+        children: 'true',
+        limit: 1024,
+      },
     };
 
     // Buffer when not incremental.
@@ -519,7 +522,7 @@ class FileSystem {
       if (options.incremental) {
         callback(null, page);
       }
-    }, args);
+    }, reqOptions);
   }
 }
 

--- a/lib/rest/client.js
+++ b/lib/rest/client.js
@@ -334,12 +334,16 @@ class Client {
     });
   }
 
-  ping(callback) {
-    const options = {
+  ping(callback, _options) {
+    let options = {
       method: 'GET',
       uri: '/api/2/ping/',
     };
 
+    if (_options) {
+      options = { ..._options, ...options };
+    }
+
     this.requestJSON(options, (e, r, json) => {
       callback(e, json);
     });
@@ -347,12 +351,16 @@ class Client {
     return this;
   }
 
-  whoami(callback) {
-    const options = {
+  whoami(callback, _options) {
+    let options = {
       method: 'GET',
       uri: '/api/2/whoami/',
     };
 
+    if (_options) {
+      options = { ..._options, ...options };
+    }
+
     this.requestJSON(options, (e, r, json) => {
       callback(e, json);
     });
@@ -360,12 +368,16 @@ class Client {
     return this;
   }
 
-  info(p, callback, args) {
+  info(p, callback, _options) {
     let pollCount = 0;
-    const options = {
+    let options = {
       method: 'GET',
       uri: `/api/2/path/info${encodePath(p)}`,
     };
+
+    if (_options) {
+      options = { ..._options, ...options };
+    }
 
     function getInfoPage(client, opts, page) {
       pollCount += 1;
@@ -403,14 +415,8 @@ class Client {
       });
     }
 
-    if (args && args.children) {
+    if (options.qs && options.qs.children) {
       // Directory listings may return more than a single item.
-      options.qs = {
-        children: 'true',
-        limit: 1024,
-      };
-      options.timeout = 30000;
-
       getInfoPage(this, options);
     } else {
       // Handle single-item info as a simpler case.
@@ -454,12 +460,12 @@ class Client {
     return req;
   }
 
-  upload(p, _s, _callback) {
+  upload(p, _s, _callback, _options) {
     const dirname = pathlib.dirname(p);
     const basename = pathlib.basename(p);
 
     const post = (callback) => {
-      const options = {
+      let options = {
         method: 'POST',
         uri: `/api/2/path/data${encodePath(dirname)}`,
         multipart: {
@@ -474,6 +480,12 @@ class Client {
         timeout: null,
       };
 
+      // NOTE: more care may be needed merging options (recursively) OTOH,
+      // overriding the options is a "pro" feature.
+      if (_options) {
+        options = { ..._options, ...options };
+      }
+
       this.requestJSON(options, (e, r, json) => {
         if (callback) {
           callback(e, json);
@@ -482,7 +494,7 @@ class Client {
     };
 
     const put = (callback) => {
-      const options = {
+      let options = {
         method: 'PUT',
         uri: `/api/2/path/data${encodePath(dirname)}`,
         headers: {
@@ -493,6 +505,12 @@ class Client {
         // Eliminate timeout for uploads.
         timeout: null,
       };
+
+      // NOTE: more care may be needed merging options (recursively) OTOH,
+      // overriding the options is a "pro" feature.
+      if (_options) {
+        options = { ..._options, ...options };
+      }
 
       return this.request(options)
         .on('response', (res) => {
@@ -541,14 +559,18 @@ class Client {
     return post(_callback);
   }
 
-  mkdir(p, callback) {
-    const options = {
+  mkdir(p, callback, _options) {
+    let options = {
       method: 'POST',
       uri: '/api/2/path/oper/mkdir/',
       form: {
         path: normPath(p),
       },
     };
+
+    if (_options) {
+      options = { ..._options, ...options };
+    }
 
     this.requestJSON(options, (e, r, json) => {
       callback(e, json);
@@ -557,14 +579,18 @@ class Client {
     return this;
   }
 
-  delete(p, callback) {
-    const options = {
+  delete(p, callback, _options) {
+    let options = {
       method: 'POST',
       uri: '/api/2/path/oper/remove/',
       form: {
         path: normPath(p),
       },
     };
+
+    if (_options) {
+      options = { ..._options, ...options };
+    }
 
     this.requestOper(options, (e, r, json) => {
       callback(e, json);
@@ -573,8 +599,8 @@ class Client {
     return this;
   }
 
-  copy(src, dst, callback) {
-    const options = {
+  copy(src, dst, callback, _options) {
+    let options = {
       method: 'POST',
       uri: '/api/2/path/oper/copy/',
       form: {
@@ -583,6 +609,10 @@ class Client {
       },
     };
 
+    if (_options) {
+      options = { ..._options, ...options };
+    }
+
     this.requestOper(options, (e, r, json) => {
       callback(e, json);
     });
@@ -590,8 +620,8 @@ class Client {
     return this;
   }
 
-  move(src, dst, callback) {
-    const options = {
+  move(src, dst, callback, _options) {
+    let options = {
       method: 'POST',
       uri: '/api/2/path/oper/move/',
       form: {
@@ -600,6 +630,10 @@ class Client {
       },
     };
 
+    if (_options) {
+      options = { ..._options, ...options };
+    }
+
     this.requestOper(options, (e, r, json) => {
       callback(e, json);
     });
@@ -607,8 +641,8 @@ class Client {
     return this;
   }
 
-  rename(src, dst, callback) {
-    const options = {
+  rename(src, dst, callback, _options) {
+    let options = {
       method: 'POST',
       uri: '/api/2/path/oper/rename/',
       form: {
@@ -616,6 +650,10 @@ class Client {
         dst: normPath(dst),
       },
     };
+
+    if (_options) {
+      options = { ..._options, ...options };
+    }
 
     this.requestJSON(options, (e, r, json) => {
       callback(e, json);

--- a/tests/test_rest.js
+++ b/tests/test_rest.js
@@ -242,7 +242,7 @@ describe('REST API client', () => {
           assert.fail('too many callbacks');
           break;
       }
-    }, { children: true });
+    }, { qs: { children: 'true', limit: 1024 } });
   });
 
   it('can retrieve a multi-page directory listing', (done) => {
@@ -283,7 +283,7 @@ describe('REST API client', () => {
           assert.fail('too many callbacks');
           break;
       }
-    }, { children: true });
+    }, { qs: { children: 'true', limit: 1024 } });
   });
 
   it('can create a directory', (done) => {
@@ -427,5 +427,27 @@ describe('REST API client', () => {
       assert(api.isDone());
       done();
     });
+  });
+
+  it('can send per-request HTTP headers', (done) => {
+    /*
+    This test calls the whoami API endpoint.
+
+    The test confirms that a header can be provided for the request.
+    */
+    const api = nock(API_URL, {
+      reqheaders: {
+        'X-Something': 'foobar',
+      },
+    })
+      .get('/api/2/whoami/')
+      .reply(200, '{ "username": "user" }');
+
+    client.whoami((e, json) => {
+      assertNoError(e);
+      assert(json.username === 'user');
+      assert(api.isDone());
+      done();
+    }, { headers: { 'X-Something': 'foobar' } });
   });
 });


### PR DESCRIPTION
This one will allow headers needed for range requests and audit events etc.