### PR TITLE
Rename some vars, return request obj from download().

### DIFF
--- a/lib/fs/filesystem.js
+++ b/lib/fs/filesystem.js
@@ -241,14 +241,14 @@ class FileSystem {
     }
 
     const end = OPERATION.startTimer({ opName: 'createReadStream' });
-    this.rest.download(path, (e, s) => {
+    return this.rest.download(path, (e, res) => {
       if (e) {
         end({ status: 'error' });
       } else {
-        s.once('end', () => end({ status: 'success' }));
+        res.once('end', () => end({ status: 'success' }));
       }
 
-      callback(e, s);
+      callback(e, res);
     }, options);
   }
 


### PR DESCRIPTION
I want access to the request object used for by `createReadStream()` so I can `abort()` it. The download data flows over a response stream provided by the callback, but the request object is useful for managing the overall request.