### PR TITLE
Key API updates and bug fixes.

### DIFF
--- a/lib/keys.js
+++ b/lib/keys.js
@@ -1,3 +1,4 @@
+const crypto = require('crypto');
 const { logger } = require('./rest/client');
 
 
@@ -124,6 +125,25 @@ class Keys {
       this.keyCache[json.name] = json;
 
       if (callback) callback(e, json);
+    });
+  }
+
+  find(key, callback) {
+    this.list((e, keys) => {
+      if (e) {
+        if (callback) callback(e);
+        return;
+      }
+
+      for (let i = 0; i < keys.length; i++) {
+        const [algo, b64Key] = keys[i].key.split(' ');
+        if (key.algo === algo
+            && crypto.timingSafeEqual(Buffer.from(b64Key, 'base64'), givenKey)) {
+          return keys[i];
+        }
+      }
+
+      return null;
     });
   }
 }

--- a/lib/keys.js
+++ b/lib/keys.js
@@ -143,6 +143,7 @@ class Keys {
             && givenKey.data.length === currKey.length
             && crypto.timingSafeEqual(currKey, givenKey.data)) {
           callback(null, keys[i]);
+          return;
         }
       }
 

--- a/lib/keys.js
+++ b/lib/keys.js
@@ -5,9 +5,16 @@ class Keys {
   constructor(rest, username) {
     this.rest = rest;
     this.username = username;
+    this.keyCache = null;
   }
 
   get(name, callback) {
+    if (this.keyCache && this.keyCache[name]) {
+      // Satisfy from cache.
+      callback(null, this.keyCache[name]);
+      return;
+    }
+
     const options = {
       method: 'get',
       uri: `/api/3/sshkeys/${this.username}/${name}`,
@@ -20,11 +27,21 @@ class Keys {
         return;
       }
 
+      // Update the cache.
+      if (this.keyCache === null) this.keyCache = {};
+      this.keyCache[json.name] = json;
+
       if (callback) callback(e, json);
     });
   }
 
   list(callback) {
+    // Satisfy from cache.
+    if (this.keyCache !== null) {
+      callback(null, Object.values(this.keyCache));
+      return;
+    }
+
     const options = {
       method: 'get',
       uri: `/api/3/sshkeys/${this.username}/`,
@@ -36,6 +53,12 @@ class Keys {
         if (callback) callback(e);
         return;
       }
+
+      // Refill the cache.
+      this.keyCache = {};
+      json.forEach((key) => {
+        this.keyCache[key.name] = key;
+      });
 
       if (callback) callback(e, json);
     });
@@ -52,6 +75,9 @@ class Keys {
         if (callback) callback(e);
         return;
       }
+
+      // Update the cache
+      if (this.keyCache !== null) delete this.keyCache[name];
 
       if (callback) callback();
     }).end();
@@ -71,6 +97,10 @@ class Keys {
         return;
       }
 
+      // Update the cache
+      if (this.keyCache === null) this.keyCache = {};
+      this.keyCache[json.name] = json;
+
       if (callback) callback(e, json);
     });
   }
@@ -88,6 +118,10 @@ class Keys {
         if (callback) callback(e);
         return;
       }
+
+      // Update the cache
+      if (this.keyCache === null) this.keyCache = {};
+      this.keyCache[json.name] = json;
 
       if (callback) callback(e, json);
     });

--- a/lib/keys.js
+++ b/lib/keys.js
@@ -10,7 +10,7 @@ class Keys {
   get(name, callback) {
     const options = {
       method: 'get',
-      uri: `/api/3/sshkeys/${this.username}/${name}/`,
+      uri: `/api/3/sshkeys/${this.username}/${name}`,
     };
 
     this.rest.requestJson(options, (e, r, json) => {
@@ -44,7 +44,7 @@ class Keys {
   delete(name, callback) {
     const options = {
       method: 'delete',
-      uri: `/api/3/sshkeys/${this.username}/${name}/`,
+      uri: `/api/3/sshkeys/${this.username}/${name}`,
     };
 
     this.rest.request(options, (e) => {
@@ -78,7 +78,7 @@ class Keys {
   update(name, obj, callback) {
     const options = {
       method: 'patch',
-      uri: `/api/3/sshkeys/${this.username}/${name}/`,
+      uri: `/api/3/sshkeys/${this.username}/${name}`,
       json: obj,
     };
 

--- a/lib/keys.js
+++ b/lib/keys.js
@@ -137,8 +137,11 @@ class Keys {
 
       for (let i = 0; i < keys.length; i++) {
         const [algo, b64Key] = keys[i].key.split(' ');
+        const currKey = Buffer.from(b64Key, 'base64');
+
         if (givenKey.algo === algo
-            && crypto.timingSafeEqual(Buffer.from(b64Key, 'base64'), givenKey.data)) {
+            && givenKey.data.length === currKey.length
+            && crypto.timingSafeEqual(currKey, givenKey.data)) {
           callback(null, keys[i]);
         }
       }

--- a/lib/keys.js
+++ b/lib/keys.js
@@ -16,11 +16,11 @@ class Keys {
     this.rest.requestJson(options, (e, r, json) => {
       if (e) {
         logger.error(e);
-        callback(e);
+        if (callback) callback(e);
         return;
       }
 
-      callback(e, json);
+      if (callback) callback(e, json);
     });
   }
 
@@ -33,11 +33,11 @@ class Keys {
     this.rest.requestJson(options, (e, r, json) => {
       if (e) {
         logger.error(e);
-        callback(e);
+        if (callback) callback(e);
         return;
       }
 
-      callback(e, json);
+      if (callback) callback(e, json);
     });
   }
 
@@ -49,29 +49,29 @@ class Keys {
 
     this.rest.request(options, (e) => {
       if (e) {
-        callback(e);
+        if (callback) callback(e);
         return;
       }
 
-      callback();
+      if (callback) callback();
     }).end();
   }
 
-  add(obj, callback) {
+  save(obj, callback) {
     const options = {
-      method: 'post',
-      uri: `/api/3/sshkeys/${this.username}/`,
+      method: 'put',
+      uri: `/api/3/sshkeys/${this.username}/${obj.name}`,
       json: obj,
     };
 
     this.rest.requestJson(options, (e, r, json) => {
       if (e) {
         logger.error(e);
-        callback(e);
+        if (callback) callback(e);
         return;
       }
 
-      callback(e, json);
+      if (callback) callback(e, json);
     });
   }
 
@@ -85,11 +85,11 @@ class Keys {
     this.rest.requestJson(options, (e, r, json) => {
       if (e) {
         logger.error(e);
-        callback(e);
+        if (callback) callback(e);
         return;
       }
 
-      callback(e, json);
+      if (callback) callback(e, json);
     });
   }
 }

--- a/lib/keys.js
+++ b/lib/keys.js
@@ -128,7 +128,7 @@ class Keys {
     });
   }
 
-  find(key, callback) {
+  find(givenKey, callback) {
     this.list((e, keys) => {
       if (e) {
         if (callback) callback(e);
@@ -137,13 +137,13 @@ class Keys {
 
       for (let i = 0; i < keys.length; i++) {
         const [algo, b64Key] = keys[i].key.split(' ');
-        if (key.algo === algo
-            && crypto.timingSafeEqual(Buffer.from(b64Key, 'base64'), givenKey)) {
-          return keys[i];
+        if (givenKey.algo === algo
+            && crypto.timingSafeEqual(Buffer.from(b64Key, 'base64'), givenKey.data)) {
+          callback(null, keys[i]);
         }
       }
 
-      return null;
+      callback(null, null);
     });
   }
 }

--- a/lib/rest/client.js
+++ b/lib/rest/client.js
@@ -139,10 +139,9 @@ class Client {
       });
     }
 
-    const reqOptions = {
-      ...this.options,
-      method: options.method,
-    };
+    // Deep copy global options so our local options don't pollute them.
+    const reqOptions = JSON.parse(JSON.stringify(this.options));
+    reqOptions.method = options.method;
 
     if (!reqOptions.headers) {
       reqOptions.headers = {};

--- a/tests/test_keys.js
+++ b/tests/test_keys.js
@@ -54,7 +54,7 @@ describe('SSH Key Management', () => {
 
   it('can get a key', (done) => {
     const api0 = server
-      .get('/api/3/sshkeys/foobar/foo/')
+      .get('/api/3/sshkeys/foobar/foo')
       .reply(200, JSON.stringify(KEY0));
 
     keys.get(KEY0.name, (e, json) => {
@@ -80,7 +80,7 @@ describe('SSH Key Management', () => {
 
   it('can update a key', (done) => {
     const api0 = server
-      .patch('/api/3/sshkeys/foobar/foo/', KEY1)
+      .patch('/api/3/sshkeys/foobar/foo', KEY1)
       .reply(200, JSON.stringify(KEY1));
 
     keys.update('foo', KEY1, (e, json) => {
@@ -93,7 +93,7 @@ describe('SSH Key Management', () => {
 
   it('can delete a key', (done) => {
     const api0 = server
-      .delete('/api/3/sshkeys/foobar/foo/')
+      .delete('/api/3/sshkeys/foobar/foo')
       .reply(204);
 
     keys.delete('foo', (e) => {

--- a/tests/test_keys.js
+++ b/tests/test_keys.js
@@ -65,12 +65,12 @@ describe('SSH Key Management', () => {
     });
   });
 
-  it('can add a key', (done) => {
+  it('can save a key', (done) => {
     const api0 = server
-      .post('/api/3/sshkeys/foobar/', KEY0)
+      .put('/api/3/sshkeys/foobar/foo', KEY0)
       .reply(200, JSON.stringify(KEY0));
 
-    keys.add(KEY0, (e, json) => {
+    keys.save(KEY0, (e, json) => {
       assertNoError(e);
       assert(api0.isDone());
       assert(json.name === KEY0.name);


### PR DESCRIPTION
This PR makes a few small changes to the API client.
- The trailing slash after key name bothered me so I removed it. The slash after username is still necessary.
- PUT method is now used to create AND update keys. This means we save a round-trip to check if something exists before saving it.
- I added caching for keys, this benefits downstream in several ways, I am able to remove some caching. Round trips are reduced.
- Deep copy global options when making an HTTP request so that they are not polluted.