### PR TITLE
HTTP_REQUEST metric endpoint label.

### DIFF
--- a/lib/rest/client.js
+++ b/lib/rest/client.js
@@ -63,7 +63,7 @@ const MAX_POLL_TIMEOUT = 393216; // About 6.5 minutes
 function normPath(_path, _leadingSlash) {
   const leadingSlash = (_leadingSlash === undefined) ? true : _leadingSlash;
   let path = _path;
-  
+
   if (leadingSlash && path[0] !== '/') {
     path = `/${path}`;
   }
@@ -82,7 +82,7 @@ function encodePath(_path) {
     parts[i] = encodeURIComponent(parts[i]);
   }
 
-  let path = parts.join('/');
+  const path = parts.join('/');
 
   return path;
 }
@@ -307,7 +307,7 @@ class Client {
       const self = this;
       const pollOptions = {
         method: 'GET',
-        uri: `/api/2/task/`,
+        uri: '/api/2/task/',
         path: `${json0.uuid}/`,
       };
       let pollInterval = MIN_POLL_INTERVAL;
@@ -429,7 +429,6 @@ class Client {
   }
 
   info(p, callback, _options) {
-    debugger;
     let pollCount = 0;
     let options = {
       method: 'GET',

--- a/lib/rest/client.js
+++ b/lib/rest/client.js
@@ -60,21 +60,31 @@ const MAX_POLL_INTERVAL = 6144; //  About 6 seconds
 const MAX_POLL_TIMEOUT = 393216; // About 6.5 minutes
 
 
-function normPath(path) {
-  if (!path.startsWith('/')) {
-    return `/${path}`;
+function normPath(_path, _leadingSlash) {
+  const leadingSlash = (_leadingSlash === undefined) ? true : _leadingSlash;
+  let path = _path;
+  
+  if (leadingSlash && path[0] !== '/') {
+    path = `/${path}`;
   }
+
+  while (!leadingSlash && path[0] === '/') {
+    path = path.slice(1);
+  }
+
   return path;
 }
 
-function encodePath(path) {
-  const parts = normPath(path).split('/');
+function encodePath(_path) {
+  const parts = normPath(_path).split('/');
 
   for (let i = 0; i < parts.length; i++) {
     parts[i] = encodeURIComponent(parts[i]);
   }
 
-  return parts.join('/');
+  let path = parts.join('/');
+
+  return path;
 }
 
 function parseJson(req, res, callback) {
@@ -131,7 +141,7 @@ class Client {
     let multipart = null;
     let body = null;
     const reqUrl = new URL(this.baseUrl);
-    reqUrl.pathname = options.uri;
+    reqUrl.pathname = (options.path) ? pathlib.join(options.uri, options.path) : options.uri;
 
     if (options.qs) {
       Object.keys(options.qs).forEach((key) => {
@@ -193,7 +203,7 @@ class Client {
 
     const end = HTTP_REQUEST.startTimer({
       method: reqOptions.method,
-      endpoint: reqUrl.pathname,
+      endpoint: options.uri,
     });
 
     let req;
@@ -297,7 +307,8 @@ class Client {
       const self = this;
       const pollOptions = {
         method: 'GET',
-        uri: `/api/2/task/${json0.uuid}/`,
+        uri: `/api/2/task/`,
+        path: `${json0.uuid}/`,
       };
       let pollInterval = MIN_POLL_INTERVAL;
 
@@ -418,10 +429,12 @@ class Client {
   }
 
   info(p, callback, _options) {
+    debugger;
     let pollCount = 0;
     let options = {
       method: 'GET',
-      uri: `/api/2/path/info${encodePath(normPath(p))}`,
+      uri: '/api/2/path/info/',
+      path: encodePath(normPath(p, false)),
     };
 
     if (_options) {
@@ -482,7 +495,8 @@ class Client {
     // only applies until the server starts sending the response.
     let options = {
       method: 'GET',
-      uri: `/api/2/path/data${encodePath(normPath(p))}`,
+      uri: '/api/2/path/data/',
+      path: encodePath(normPath(p), false),
     };
 
     if (_options) {
@@ -539,7 +553,8 @@ class Client {
       options = {
         ...options,
         method: 'POST',
-        uri: `/api/2/path/data${encodePath(normPath(dirname))}`,
+        uri: '/api/2/path/data/',
+        path: encodePath(normPath(dirname, false)),
         multipart: {
           file: {
             value: _s,
@@ -564,7 +579,8 @@ class Client {
       options = {
         ...options,
         method: 'PATCH',
-        uri: `/api/3/path/data${encodePath(normPath(p))}`,
+        uri: '/api/3/path/data/',
+        path: encodePath(normPath(p, false)),
       };
 
       if (!options.headers['If-Unmodified-Since']) {
@@ -579,7 +595,8 @@ class Client {
       options = {
         ...options,
         method: 'PUT',
-        uri: `/api/3/path/data${encodePath(normPath(p))}`,
+        uri: '/api/3/path/data/',
+        path: encodePath(normPath(p, false)),
         headers: {
           // TODO: lua requires this for now, fix that!
           'Content-Type': 'application/octet-stream',
@@ -652,7 +669,8 @@ class Client {
   deleteFile(p, callback, _options) {
     let options = {
       method: 'DELETE',
-      uri: `/api/3/path/data${encodePath(normPath(p))}`,
+      uri: '/api/3/path/data/',
+      path: encodePath(normPath(p, false)),
     };
 
     if (_options) {


### PR DESCRIPTION
The metric label `endpoint` included path (which is actually an argument). This produces a wide variety of `endpoint` labels, disallowing graphs by `endpoint`. This PR separates them until the request is performed.