### PR TITLE
Use new error, original error references req/res.

### DIFF
--- a/lib/fs/filesystem.js
+++ b/lib/fs/filesystem.js
@@ -125,8 +125,11 @@ class FileSystem {
     operationWrapper(this.rest, 'info', [path], (e, json) => {
       if (e) {
         if (e.statusCode === 404) {
-          // Negative cache.
-          this._addCache(path, e, 2);
+          // Negative cache, don't use the original (heavyweight) error instance.
+          const newError = new Error('File not found');
+          newError.statusCode = e.statusCode;
+          newError.message = e.message;
+          this._addCache(path, newError, 2);
         }
         callback(e);
         return;


### PR DESCRIPTION
Caching the error returned by the rest client can causes problems downstream. The error holds references to the http request and response and can contain circular references. There is no reason to use the original error (or an actual error object at all really) so just create a new one.