### PR TITLE
Result.result

### DIFF
--- a/lib/fs/filesystem.js
+++ b/lib/fs/filesystem.js
@@ -125,8 +125,11 @@ class FileSystem {
     operationWrapper(this.rest, 'info', [path], (e, json) => {
       if (e) {
         if (e.statusCode === 404) {
-          // Negative cache.
-          this._addCache(path, e, 2);
+          // Negative cache, don't use the original (heavyweight) error instance.
+          const newError = new Error('File not found');
+          newError.statusCode = e.statusCode;
+          newError.message = e.message;
+          this._addCache(path, newError, 2);
         }
         callback(e);
         return;

--- a/lib/rest/client.js
+++ b/lib/rest/client.js
@@ -330,7 +330,9 @@ class Client {
             return;
           }
 
+          // Safely retrieve any errors that occurred during the operation.
           const errors = (json1.result.result) ? json1.result.result.errors : undefined;
+
           switch (json1.result.status) {
             case 'PENDING':
             case 'PROGRESS':
@@ -346,6 +348,7 @@ class Client {
               break;
 
             case 'FAILURE':
+              // The operation failed outright (500, 400 etc.)
               OPERATION.observe({
                 status: 'error',
                 endpoint: pollOptions.uri,
@@ -358,8 +361,8 @@ class Client {
               break;
 
             case 'SUCCESS':
-              // Sometimes an error occurrs during the operation (partial failure).
-              if (json1.result.result && json1.result.result.errors) {
+              // Sometimes an error occurs during the operation (partial failure).
+              if (errors) {
                 resError = new Error(`Partial failure: result.result.errors=${errors}`);
                 resError.statusCode = r1.statusCode;
 

--- a/lib/rest/client.js
+++ b/lib/rest/client.js
@@ -330,6 +330,7 @@ class Client {
             return;
           }
 
+          const errors = (json1.result.result) ? json1.result.result.errors : undefined;
           switch (json1.result.status) {
             case 'PENDING':
             case 'PROGRESS':
@@ -350,8 +351,7 @@ class Client {
                 endpoint: pollOptions.uri,
               }, pollCount);
 
-              const errors = (json1.result.result) ? json1.result.result.errors : 'Unknown error';
-              resError = new Error(`Task failed: ${errors}`);
+              resError = new Error(`Task failed: result.result.errors=${errors}`);
               resError.statusCode = r1.statusCode;
               resError.request = req;
               callback(resError, r1, json1);
@@ -360,7 +360,7 @@ class Client {
             case 'SUCCESS':
               // Sometimes an error occurrs during the operation (partial failure).
               if (json1.result.result && json1.result.result.errors) {
-                resError = new Error('Operation reported errors');
+                resError = new Error(`Partial failure: result.result.errors=${errors}`);
                 resError.statusCode = r1.statusCode;
 
                 OPERATION.observe({

--- a/lib/rest/client.js
+++ b/lib/rest/client.js
@@ -350,15 +350,16 @@ class Client {
                 endpoint: pollOptions.uri,
               }, pollCount);
 
-              resError = new Error(`Task failed: ${json1.result.result.errors}`);
+              const errors = (json1.result.result) ? json1.result.result.errors : 'Unknown error';
+              resError = new Error(`Task failed: ${errors}`);
               resError.statusCode = r1.statusCode;
               resError.request = req;
               callback(resError, r1, json1);
               break;
 
             case 'SUCCESS':
-              if (json1.result.result.errors) {
-                // In this case some error occurred during the operation.
+              // Sometimes an error occurrs during the operation (partial failure).
+              if (json1.result.result && json1.result.result.errors) {
                 resError = new Error('Operation reported errors');
                 resError.statusCode = r1.statusCode;
 


### PR DESCRIPTION
Don't blindly access `result.result` attribute in API response.

Fixes https://github.com/smartfile/client-node/issues/59