### PR TITLE
Always URI encode paths on URI.

### DIFF
--- a/lib/rest/client.js
+++ b/lib/rest/client.js
@@ -75,8 +75,8 @@ function normPath(_path, _leadingSlash) {
   return path;
 }
 
-function encodePath(_path) {
-  const parts = normPath(_path).split('/');
+function encodePath(_path, _leadingSlash) {
+  const parts = normPath(_path, _leadingSlash).split('/');
 
   for (let i = 0; i < parts.length; i++) {
     parts[i] = encodeURIComponent(parts[i]);
@@ -433,7 +433,7 @@ class Client {
     let options = {
       method: 'GET',
       uri: '/api/2/path/info/',
-      path: encodePath(normPath(p, false)),
+      path: encodePath(p, false),
     };
 
     if (_options) {
@@ -495,7 +495,7 @@ class Client {
     let options = {
       method: 'GET',
       uri: '/api/2/path/data/',
-      path: encodePath(normPath(p), false),
+      path: encodePath(p, false),
     };
 
     if (_options) {
@@ -553,7 +553,7 @@ class Client {
         ...options,
         method: 'POST',
         uri: '/api/2/path/data/',
-        path: encodePath(normPath(dirname, false)),
+        path: encodePath(dirname, false),
         multipart: {
           file: {
             value: _s,
@@ -579,7 +579,7 @@ class Client {
         ...options,
         method: 'PATCH',
         uri: '/api/3/path/data/',
-        path: encodePath(normPath(p, false)),
+        path: encodePath(p, false),
       };
 
       if (!options.headers['If-Unmodified-Since']) {
@@ -595,7 +595,7 @@ class Client {
         ...options,
         method: 'PUT',
         uri: '/api/3/path/data/',
-        path: encodePath(normPath(p, false)),
+        path: encodePath(p, false),
         headers: {
           // TODO: lua requires this for now, fix that!
           'Content-Type': 'application/octet-stream',
@@ -669,7 +669,7 @@ class Client {
     let options = {
       method: 'DELETE',
       uri: '/api/3/path/data/',
-      path: encodePath(normPath(p, false)),
+      path: encodePath(p, false),
     };
 
     if (_options) {


### PR DESCRIPTION
I was looking into this open (at the time) issue: https://github.com/smartfile/client-node/issues/57

It is apparently fixed (with a test case) but I found other issues with path handling on the URI and fixed those.