### PR TITLE
Move / copy cache eviction.

### DIFF
--- a/lib/fs/filesystem.js
+++ b/lib/fs/filesystem.js
@@ -1,4 +1,5 @@
 /* eslint no-underscore-dangle: ["error", { "allowAfterThis": true }] */
+const pathlib = require('path');
 const prom = require('prom-client');
 const moment = require('moment');
 const {
@@ -197,6 +198,10 @@ class FileSystem {
     // Because this is an operation, the JSON indicates the status of
     // the operation, but does not return the dst object. Therefore
     // we cannot "prime" the cache.
+    // However, we can evict the destination. I think it is safe to assume
+    // that dst is a directory (not the full path including file name).
+    const dstPath = pathlib.join(dst, pathlib.basename(src))
+    this._delCache(dstPath, 0, 1, 2);
     return operationWrapper(this.rest, 'copy', [src, dst], callback);
   }
 
@@ -212,6 +217,10 @@ class FileSystem {
     // Because this is an operation, the JSON indicates the status of
     // the operation, but does not return the dst object. Therefore
     // we cannot "prime" the cache.
+    // However, we can evict the destination. I think it is safe to assume
+    // that dst is a directory (not the full path including file name).
+    const dstPath = pathlib.join(dst, pathlib.basename(src))
+    this._delCache(dstPath, 0, 1, 2);
     return operationWrapper(this.rest, 'move', [src, dst], callback);
   }
 

--- a/lib/fs/filesystem.js
+++ b/lib/fs/filesystem.js
@@ -200,7 +200,7 @@ class FileSystem {
     // we cannot "prime" the cache.
     // However, we can evict the destination. I think it is safe to assume
     // that dst is a directory (not the full path including file name).
-    const dstPath = pathlib.join(dst, pathlib.basename(src))
+    const dstPath = pathlib.join(dst, pathlib.basename(src));
     this._delCache(dstPath, 0, 1, 2);
     return operationWrapper(this.rest, 'copy', [src, dst], callback);
   }
@@ -219,7 +219,7 @@ class FileSystem {
     // we cannot "prime" the cache.
     // However, we can evict the destination. I think it is safe to assume
     // that dst is a directory (not the full path including file name).
-    const dstPath = pathlib.join(dst, pathlib.basename(src))
+    const dstPath = pathlib.join(dst, pathlib.basename(src));
     this._delCache(dstPath, 0, 1, 2);
     return operationWrapper(this.rest, 'move', [src, dst], callback);
   }


### PR DESCRIPTION
During a move or copy, the following can occur:

 - Client checks destination before move / copy. Destination does not exist and populates cache with 404 Error.
 - Client performs move / copy operation.
 - Client reads destination information but receives cached 404 result.

This PR addresses this by evicting the destination from cache before performing the move / copy operation.