### PR TITLE
Better logging. Consistent upload options.

### DIFF
--- a/lib/rest/client.js
+++ b/lib/rest/client.js
@@ -221,7 +221,7 @@ class Client {
     const request = (reqUrl.protocol === 'http:') ? http.request : https.request;
 
     const cb = (res) => {
-      logger.debug(`${reqOptions.method}: ${reqUrl.pathname}, `
+      logger.debug(`${req.method}: ${req.path}, `
                    + `${res.statusCode}: ${res.statusMessage}`);
 
       if (res.statusCode === 429) {
@@ -603,6 +603,8 @@ class Client {
         method: 'PATCH',
         uri: '/api/3/path/data/',
         path: encodePath(p, false),
+        // Eliminate timeout for uploads.
+        timeout: null,
       };
 
       if (!options.headers['If-Unmodified-Since']) {
@@ -619,10 +621,6 @@ class Client {
         method: 'PUT',
         uri: '/api/3/path/data/',
         path: encodePath(p, false),
-        headers: {
-          // TODO: lua requires this for now, fix that!
-          'Content-Type': 'application/octet-stream',
-        },
         // Eliminate timeout for uploads.
         timeout: null,
       };


### PR DESCRIPTION
I am now (ab)using the fact that some API client methods return the request object. This affords the opportunity to modify parameters of the request such as the method and URL. When this is done, the logging statement does not reflect these changes as it logged from the options object rather than directly from the request object. This PR addresses that.

Additionally, some of the options used during upload were inconsistent. For one, the timeout was not disabled for PATCH method and also PATCH method sent an additional header that is no longer necessary.