### PR TITLE
Add session support to API client.

### DIFF
--- a/lib/rest/basic.js
+++ b/lib/rest/basic.js
@@ -85,6 +85,10 @@ class BasicClient extends Client {
 
     return this;
   }
+
+  logout() {
+    this.cookies = new CookieJar();
+  }
 }
 
 module.exports = {

--- a/lib/rest/basic.js
+++ b/lib/rest/basic.js
@@ -62,15 +62,14 @@ class BasicClient extends Client {
         this.cookies.setCookies(resCookies, reqUrl.host, reqUrl.pathname);
       }
     });
+
+    return req;
   }
 
   login(callback, _options) {
     let options = {
       method: 'POST',
       uri: '/api/2/session/',
-      qs: {
-        session: 'true',
-      },
     };
 
     if (_options) {
@@ -78,7 +77,6 @@ class BasicClient extends Client {
     }
 
     this.requestJson(options, (e, r, json) => {
-      this.cookies.add(r.headers['']);
       callback(e, json);
     });
 

--- a/lib/rest/basic.js
+++ b/lib/rest/basic.js
@@ -1,5 +1,6 @@
-const { Client } = require('./client');
+const pathlib = require('path');
 const { CookieJar, CookieAccessInfo } = require('cookiejar');
+const { Client } = require('./client');
 
 
 class BasicClient extends Client {
@@ -30,33 +31,37 @@ class BasicClient extends Client {
   }
 
   request(options, callback) {
+    const reqOptions = {
+      ...options,
+    };
+
     // We need URL details for handling cookies.
     const reqUrl = new URL(this.baseUrl);
     reqUrl.pathname = (options.path) ? pathlib.join(options.uri, options.path) : options.uri;
 
     // Any cookies for this request?
-    const cookies = this.cookies.getCookies(
+    const reqCookies = this.cookies.getCookies(
       new CookieAccessInfo(reqUrl.host, reqUrl.pathname, (reqUrl.protocol === 'https:'), false)
     );
     // Inject cookies from jar into request headers.
-    if (cookies) {
-      let cookieStrings = [];
-      for (let i = 0; i < cookies.length; i++) {
-        cookieStrings.push(cookies[i].toValueString());
+    if (reqCookies) {
+      const cookieStrings = [];
+      for (let i = 0; i < reqCookies.length; i++) {
+        cookieStrings.push(reqCookies[i].toValueString());
       }
-      options.headers['Cookie'] = cookieStrings.join('; ');
+      reqOptions.headers.Cookie = cookieStrings.join('; ');
     }
 
-    const req = super.request(options, callback);
+    const req = super.request(reqOptions, callback);
 
     req.on('response', (res) => {
       // Store cookies from server into cookie jar.
-      const cookies = res.headers['set-cookie'];
-      if (cookies) {
+      const resCookies = res.headers['set-cookie'];
+      if (resCookies) {
         // Will update existing cookies.
-        this.cookies.setCookies(cookies, reqUrl.host, reqUrl.pathname);
+        this.cookies.setCookies(resCookies, reqUrl.host, reqUrl.pathname);
       }
-    })
+    });
   }
 
   login(callback, _options) {
@@ -64,7 +69,7 @@ class BasicClient extends Client {
       method: 'POST',
       uri: '/api/2/session/',
       qs: {
-        'session': 'true',
+        session: 'true',
       },
     };
 

--- a/lib/rest/basic.js
+++ b/lib/rest/basic.js
@@ -49,6 +49,9 @@ class BasicClient extends Client {
       for (let i = 0; i < reqCookies.length; i++) {
         cookieStrings.push(reqCookies[i].toValueString());
       }
+      reqOptions.headers = {
+        ...reqOptions.headers,
+      };
       reqOptions.headers.Cookie = cookieStrings.join('; ');
     }
 
@@ -59,7 +62,7 @@ class BasicClient extends Client {
       const resCookies = res.headers['set-cookie'];
       if (resCookies) {
         // Will update existing cookies.
-        this.cookies.setCookies(resCookies, reqUrl.host, reqUrl.pathname);
+        this.cookies.setCookies(resCookies, reqUrl.host);
       }
     });
 

--- a/lib/rest/basic.js
+++ b/lib/rest/basic.js
@@ -1,4 +1,5 @@
 const { Client } = require('./client');
+const { CookieJar, CookieAccessInfo } = require('cookiejar');
 
 
 class BasicClient extends Client {
@@ -23,8 +24,60 @@ class BasicClient extends Client {
     }
 
     options.auth = `${username}:${password}`;
-
     super(options);
+
+    this.cookies = new CookieJar();
+  }
+
+  request(options, callback) {
+    // We need URL details for handling cookies.
+    const reqUrl = new URL(this.baseUrl);
+    reqUrl.pathname = (options.path) ? pathlib.join(options.uri, options.path) : options.uri;
+
+    // Any cookies for this request?
+    const cookies = this.cookies.getCookies(
+      new CookieAccessInfo(reqUrl.host, reqUrl.pathname, (reqUrl.protocol === 'https:'), false)
+    );
+    // Inject cookies from jar into request headers.
+    if (cookies) {
+      let cookieStrings = [];
+      for (let i = 0; i < cookies.length; i++) {
+        cookieStrings.push(cookies[i].toValueString());
+      }
+      options.headers['Cookie'] = cookieStrings.join('; ');
+    }
+
+    const req = super.request(options, callback);
+
+    req.on('response', (res) => {
+      // Store cookies from server into cookie jar.
+      const cookies = res.headers['set-cookie'];
+      if (cookies) {
+        // Will update existing cookies.
+        this.cookies.setCookies(cookies, reqUrl.host, reqUrl.pathname);
+      }
+    })
+  }
+
+  login(callback, _options) {
+    let options = {
+      method: 'POST',
+      uri: '/api/2/session/',
+      qs: {
+        'session': 'true',
+      },
+    };
+
+    if (_options) {
+      options = { ..._options, ...options };
+    }
+
+    this.requestJson(options, (e, r, json) => {
+      this.cookies.add(r.headers['']);
+      callback(e, json);
+    });
+
+    return this;
   }
 }
 

--- a/lib/rest/basic.js
+++ b/lib/rest/basic.js
@@ -106,7 +106,7 @@ class BasicClient extends Client {
       uri: '/api/2/session/',
     };
 
-    this.requestJson(options, (e, r, json) => {
+    this.requestJson(options, (e) => {
       this.cookies = new CookieJar();
       this.options.auth = `${this.username}:${this.password}`;
       callback(e);

--- a/lib/rest/basic.js
+++ b/lib/rest/basic.js
@@ -65,7 +65,6 @@ class BasicClient extends Client {
           // Add CSRF token to headers.
           'X-CSRFToken': csrfCookie.value,
         };
-        console.log(csrfCookie.value);
       }
     }
 

--- a/lib/rest/basic.js
+++ b/lib/rest/basic.js
@@ -27,6 +27,8 @@ class BasicClient extends Client {
     options.auth = `${username}:${password}`;
     super(options);
 
+    this.username = username;
+    this.password = password;
     this.cookies = new CookieJar();
   }
 
@@ -38,11 +40,10 @@ class BasicClient extends Client {
     // We need URL details for handling cookies.
     const reqUrl = new URL(this.baseUrl);
     reqUrl.pathname = (options.path) ? pathlib.join(options.uri, options.path) : options.uri;
+    const cai = new CookieAccessInfo(reqUrl.host, reqUrl.pathname, (reqUrl.protocol === 'https:'), false);
 
     // Any cookies for this request?
-    const reqCookies = this.cookies.getCookies(
-      new CookieAccessInfo(reqUrl.host, reqUrl.pathname, (reqUrl.protocol === 'https:'), false)
-    );
+    const reqCookies = this.cookies.getCookies(cai);
     // Inject cookies from jar into request headers.
     if (reqCookies) {
       const cookieStrings = [];
@@ -51,8 +52,21 @@ class BasicClient extends Client {
       }
       reqOptions.headers = {
         ...reqOptions.headers,
+        Cookie: cookieStrings.join('; '),
       };
-      reqOptions.headers.Cookie = cookieStrings.join('; ');
+    }
+
+    // Handle CSRF token for some requests.
+    if (['GET', 'HEAD', 'OPTIONS', 'TRACE'].indexOf(reqOptions.method.toUpperCase()) === -1) {
+      const csrfCookie = this.cookies.getCookie('csrftoken', cai);
+      if (csrfCookie) {
+        reqOptions.headers = {
+          ...reqOptions.headers,
+          // Add CSRF token to headers.
+          'X-CSRFToken': csrfCookie.value,
+        };
+        console.log(csrfCookie.value);
+      }
     }
 
     const req = super.request(reqOptions, callback);
@@ -63,6 +77,7 @@ class BasicClient extends Client {
       if (resCookies) {
         // Will update existing cookies.
         this.cookies.setCookies(resCookies, reqUrl.host);
+        delete this.options.auth;
       }
     });
 
@@ -88,6 +103,7 @@ class BasicClient extends Client {
 
   logout() {
     this.cookies = new CookieJar();
+    this.options.auth = `${this.username}:${this.password}`;
   }
 }
 

--- a/lib/rest/basic.js
+++ b/lib/rest/basic.js
@@ -100,9 +100,17 @@ class BasicClient extends Client {
     return this;
   }
 
-  logout() {
-    this.cookies = new CookieJar();
-    this.options.auth = `${this.username}:${this.password}`;
+  logout(callback) {
+    const options = {
+      method: 'DELETE',
+      uri: '/api/2/session/',
+    };
+
+    this.requestJson(options, (e, r, json) => {
+      this.cookies = new CookieJar();
+      this.options.auth = `${this.username}:${this.password}`;
+      callback(e);
+    });
   }
 }
 

--- a/lib/rest/basic.js
+++ b/lib/rest/basic.js
@@ -29,6 +29,7 @@ class BasicClient extends Client {
   }
 
   authenticate(options) {
+    // eslint-disable-next-line no-param-reassign
     options.auth = `${this.username}:${this.password}`;
   }
 }

--- a/lib/rest/basic.js
+++ b/lib/rest/basic.js
@@ -1,5 +1,3 @@
-const pathlib = require('path');
-const { CookieJar, CookieAccessInfo } = require('cookiejar');
 const { Client } = require('./client');
 
 
@@ -24,93 +22,14 @@ class BasicClient extends Client {
       password = options.auth.pass || options.auth.password;
     }
 
-    options.auth = `${username}:${password}`;
     super(options);
 
     this.username = username;
     this.password = password;
-    this.cookies = new CookieJar();
   }
 
-  request(options, callback) {
-    const reqOptions = {
-      ...options,
-    };
-
-    // We need URL details for handling cookies.
-    const reqUrl = new URL(this.baseUrl);
-    reqUrl.pathname = (options.path) ? pathlib.join(options.uri, options.path) : options.uri;
-    const cai = new CookieAccessInfo(reqUrl.host, reqUrl.pathname, (reqUrl.protocol === 'https:'), false);
-
-    // Any cookies for this request?
-    const reqCookies = this.cookies.getCookies(cai);
-    // Inject cookies from jar into request headers.
-    if (reqCookies) {
-      const cookieStrings = [];
-      for (let i = 0; i < reqCookies.length; i++) {
-        cookieStrings.push(reqCookies[i].toValueString());
-      }
-      reqOptions.headers = {
-        ...reqOptions.headers,
-        Cookie: cookieStrings.join('; '),
-      };
-    }
-
-    // Handle CSRF token for some requests.
-    if (['GET', 'HEAD', 'OPTIONS', 'TRACE'].indexOf(reqOptions.method.toUpperCase()) === -1) {
-      const csrfCookie = this.cookies.getCookie('csrftoken', cai);
-      if (csrfCookie) {
-        reqOptions.headers = {
-          ...reqOptions.headers,
-          // Add CSRF token to headers.
-          'X-CSRFToken': csrfCookie.value,
-        };
-      }
-    }
-
-    const req = super.request(reqOptions, callback);
-
-    req.on('response', (res) => {
-      // Store cookies from server into cookie jar.
-      const resCookies = res.headers['set-cookie'];
-      if (resCookies) {
-        // Will update existing cookies.
-        this.cookies.setCookies(resCookies, reqUrl.host);
-        delete this.options.auth;
-      }
-    });
-
-    return req;
-  }
-
-  login(callback, _options) {
-    let options = {
-      method: 'POST',
-      uri: '/api/2/session/',
-    };
-
-    if (_options) {
-      options = { ..._options, ...options };
-    }
-
-    this.requestJson(options, (e, r, json) => {
-      callback(e, json);
-    });
-
-    return this;
-  }
-
-  logout(callback) {
-    const options = {
-      method: 'DELETE',
-      uri: '/api/2/session/',
-    };
-
-    this.requestJson(options, (e) => {
-      this.cookies = new CookieJar();
-      this.options.auth = `${this.username}:${this.password}`;
-      callback(e);
-    });
+  authenticate(options) {
+    options.auth = `${this.username}:${this.password}`;
   }
 }
 

--- a/lib/rest/client.js
+++ b/lib/rest/client.js
@@ -223,7 +223,7 @@ class Client {
     if (reqCookies) {
       const cookieStrings = [];
       for (let i = 0; i < reqCookies.length; i++) {
-        if (reqCookies[i].name == 'sessionid') {
+        if (reqCookies[i].name === 'sessionid') {
           usingSession = true;
         }
         cookieStrings.push(reqCookies[i].toValueString());
@@ -334,6 +334,7 @@ class Client {
     return req;
   }
 
+  // eslint-disable-next-line class-methods-use-this, no-unused-vars
   authenticate(options) {
     // NOOP
   }
@@ -871,7 +872,8 @@ class Client {
       // Remove session & csrf cookies.
       const sessionCookie = new Cookie('sessionid=null', reqUrl.host, '/');
       const csrfCookie = new Cookie('csrftoken=null', reqUrl.host, '/');
-      csrfCookie.expiration_date = sessionCookie.expiration_date = new Date(-8640000000000000);
+      csrfCookie.expiration_date = new Date(-8640000000000000);
+      sessionCookie.expiration_date = new Date(-8640000000000000);
       this.cookies.setCookie(sessionCookie, reqUrl.host, '/');
       this.cookies.setCookie(csrfCookie, reqUrl.host, '/');
 

--- a/lib/rest/client.js
+++ b/lib/rest/client.js
@@ -7,6 +7,7 @@ const winston = require('winston');
 const pathlib = require('path');
 const prom = require('prom-client');
 const utf8 = require('utf8');
+const { CookieJar, Cookie, CookieAccessInfo } = require('cookiejar');
 
 
 const TZ = moment().tz('America/Indiana/Indianapolis').format('Z');
@@ -144,6 +145,7 @@ class Client {
       timeout: opts.timeout || 30000,
       headers: opts.headers,
     };
+    this.cookies = new CookieJar();
   }
 
   request(options, callback) {
@@ -210,6 +212,44 @@ class Client {
       });
     }
 
+    // We need URL details for handling cookies.
+    const cai = new CookieAccessInfo(reqUrl.host, reqUrl.pathname, (reqUrl.protocol === 'https:'), false);
+
+    // Any cookies for this request?
+    const reqCookies = this.cookies.getCookies(cai);
+    let usingSession = false;
+
+    // Inject cookies from jar into request headers.
+    if (reqCookies) {
+      const cookieStrings = [];
+      for (let i = 0; i < reqCookies.length; i++) {
+        if (reqCookies[i].name == 'sessionid') {
+          usingSession = true;
+        }
+        cookieStrings.push(reqCookies[i].toValueString());
+      }
+      reqOptions.headers = {
+        ...reqOptions.headers,
+        Cookie: cookieStrings.join('; '),
+      };
+    }
+
+    // Handle CSRF token for some requests.
+    if (['GET', 'HEAD', 'OPTIONS', 'TRACE'].indexOf(reqOptions.method.toUpperCase()) === -1) {
+      const csrfCookie = this.cookies.getCookie('csrftoken', cai);
+      if (csrfCookie) {
+        reqOptions.headers = {
+          ...reqOptions.headers,
+          // Add CSRF token to headers.
+          'X-CSRFToken': csrfCookie.value,
+        };
+      }
+    }
+
+    if (!usingSession) {
+      this.authenticate(reqOptions);
+    }
+
     const end = HTTP_REQUEST.startTimer({
       method: reqOptions.method,
       endpoint: options.uri,
@@ -270,6 +310,15 @@ class Client {
 
     req = request(reqUrl, reqOptions, cb);
 
+    req.on('response', (res) => {
+      // Store cookies from server into cookie jar.
+      const resCookies = res.headers['set-cookie'];
+      if (resCookies) {
+        // Will update existing cookies.
+        this.cookies.setCookies(resCookies, reqUrl.host);
+      }
+    });
+
     req.on('error', (e) => {
       if (callback) callback(e);
     });
@@ -283,6 +332,10 @@ class Client {
     }
 
     return req;
+  }
+
+  authenticate(options) {
+    // NOOP
   }
 
   requestJson(options, callback) {
@@ -780,6 +833,50 @@ class Client {
     });
 
     return this;
+  }
+
+  login(callback, _options) {
+    let options = {
+      method: 'POST',
+      uri: '/api/2/session/',
+    };
+
+    if (_options) {
+      options = { ..._options, ...options };
+    }
+
+    // Attempt login, creating a session...
+    this.requestJson(options, (e) => {
+      if (e) {
+        callback(e);
+        return;
+      }
+
+      // NOTE: success, call whoami, logins often need user info.
+      this.whoami(callback);
+    });
+
+    return this;
+  }
+
+  logout(callback) {
+    const options = {
+      method: 'DELETE',
+      uri: '/api/2/session/',
+    };
+
+    const reqUrl = new URL(this.baseUrl);
+
+    this.requestJson(options, (e) => {
+      // Remove session & csrf cookies.
+      const sessionCookie = new Cookie('sessionid=null', reqUrl.host, '/');
+      const csrfCookie = new Cookie('csrftoken=null', reqUrl.host, '/');
+      csrfCookie.expiration_date = sessionCookie.expiration_date = new Date(-8640000000000000);
+      this.cookies.setCookie(sessionCookie, reqUrl.host, '/');
+      this.cookies.setCookie(csrfCookie, reqUrl.host, '/');
+
+      callback(e);
+    });
   }
 }
 

--- a/lib/rest/client.js
+++ b/lib/rest/client.js
@@ -139,13 +139,11 @@ class Client {
     // - auth
     this.baseUrl = opts.baseUrl || process.env.SMARTFILE_API_URL || BASE_URL;
 
-    const options = {
+    this.options = {
       auth: opts.auth,
       timeout: opts.timeout || 30000,
       headers: opts.headers,
     };
-
-    this.options = options;
   }
 
   request(options, callback) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "smartfile-client",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -819,6 +819,11 @@
         }
       }
     },
+    "cookiejar": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/cookiejar/-/cookiejar-2.1.2.tgz",
+      "integrity": "sha512-Mw+adcfzPxcPeI+0WlvRrr/3lGVO0bD75SxX6811cxSh1Wbxx7xZBGK1eVtDf6si8rg2lhnUjsVLMFMfbRIuwA=="
+    },
     "core-util-is": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "smartfile-client",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "description": "SmartFile API client for node.js.",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
   "author": "SmartFile",
   "license": "MIT",
   "dependencies": {
+    "cookiejar": "^2.1.2",
     "form-data": "^3.0.0",
     "memory-streams": "^0.1.3",
     "moment": "^2.24.0",

--- a/tests/test_auth.js
+++ b/tests/test_auth.js
@@ -74,7 +74,7 @@ describe('SmartFile Basic API client', () => {
       },
     })
       .post('/api/2/session/')
-      .reply(200, '{}');
+      .reply(201, '{}');
 
     const api2 = nock(API_URL, {
       reqheaders: {

--- a/tests/test_auth.js
+++ b/tests/test_auth.js
@@ -65,7 +65,7 @@ describe('SmartFile Basic API client', () => {
         user: 'username',
         pass: 'password',
       })
-      .reply(200, '{}', { 'Set-Cookie': ['sessionid=bar', 'csrftoken=ABCD'] });
+      .reply(201, '{}', { 'Set-Cookie': ['sessionid=bar', 'csrftoken=ABCD'] });
 
     const api1 = nock(API_URL, {
       reqheaders: {
@@ -92,7 +92,7 @@ describe('SmartFile Basic API client', () => {
       },
     })
       .delete('/api/2/session/')
-      .reply(200, '{}');
+      .reply(204, '{}');
 
     const client = new BasicClient({
       username: 'username',

--- a/tests/test_auth.js
+++ b/tests/test_auth.js
@@ -68,7 +68,7 @@ describe('SmartFile Basic API client', () => {
 
     const api1 = nock(API_URL, {
       reqheaders: {
-        'Cookie': 'foo=bar',
+        Cookie: 'foo=bar',
       },
     })
       .get('/api/2/path/info/foobar')
@@ -78,23 +78,25 @@ describe('SmartFile Basic API client', () => {
       })
       .reply(200);
 
-      const client = new BasicClient({
-        username: 'username',
-        password: 'password',
-        baseUrl: API_URL,
-      });
+    const client = new BasicClient({
+      username: 'username',
+      password: 'password',
+      baseUrl: API_URL,
+    });
 
-      // Ensure we can handle Set-Cookie.
-      client.login((e) => {
-        assert.strictEqual(1, client.cookies.getCookies(new CookieAccessInfo('fakeapi.foo', '/', false, false)).length);
-        assert(api0.isDone());
+    // Ensure we can handle Set-Cookie.
+    client.login((loginError) => {
+      assert(!!loginError);
+      assert.strictEqual(1, client.cookies.getCookies(new CookieAccessInfo('fakeapi.foo', '/', false, false)).length);
+      assert(api0.isDone());
 
-        // Ensure we can handle Cookie.
-        client.info('/foobar', (e) => {
-          assert(api1.isDone());
-          done();
-        });
+      // Ensure we can handle Cookie.
+      client.info('/foobar', (infoError) => {
+        assert(!!infoError);
+        assert(api1.isDone());
+        done();
       });
+    });
   });
 
   it('can handle authentication failure', (done) => {

--- a/tests/test_auth.js
+++ b/tests/test_auth.js
@@ -95,11 +95,12 @@ describe('SmartFile Basic API client', () => {
         assert(api1.isDone());
 
         // Ensure we can handle logout().
-        client.logout();
-        // Credentials restored.
-        assert.strictEqual('username:password', client.options.auth);
-
-        done();
+        client.logout((logoutError) => {
+          // Credentials restored.
+          assert(!!logoutError);
+          assert.strictEqual('username:password', client.options.auth);
+          done();
+        });
       });
     });
   });

--- a/tests/test_auth.js
+++ b/tests/test_auth.js
@@ -68,15 +68,11 @@ describe('SmartFile Basic API client', () => {
 
     const api1 = nock(API_URL, {
       reqheaders: {
-        Cookie: ['foo=bar; csrftoken=ABCD'],
-        'X-CSRFToken': 'ABCD',
+        cookie: 'foo=bar; csrftoken=ABCD',
+        'x-csrftoken': 'ABCD',
       },
     })
-      .get('/api/2/session/')
-      .basicAuth({
-        user: 'username',
-        pass: 'password',
-      })
+      .post('/api/2/session/')
       .reply(200);
 
     const client = new BasicClient({
@@ -92,6 +88,7 @@ describe('SmartFile Basic API client', () => {
       assert(api0.isDone());
 
       // Ensure we can handle Cookie.
+      debugger;
       client.login((login1Error) => {
         assert(!!login1Error);
         assert(api1.isDone());

--- a/tests/test_auth.js
+++ b/tests/test_auth.js
@@ -88,7 +88,6 @@ describe('SmartFile Basic API client', () => {
       assert(api0.isDone());
 
       // Ensure we can handle Cookie.
-      debugger;
       client.login((login1Error) => {
         assert(!!login1Error);
         assert(api1.isDone());

--- a/tests/test_auth.js
+++ b/tests/test_auth.js
@@ -34,7 +34,7 @@ describe('SmartFile Basic API client', () => {
     assert.strictEqual(client.baseUrl, API_URL);
     assert.strictEqual(client.username, 'foobar');
     assert.strictEqual(client.password, 'baz');
-});
+  });
 
   it('can authenticate', (done) => {
     const api = nock(API_URL)
@@ -92,7 +92,7 @@ describe('SmartFile Basic API client', () => {
       },
     })
       .delete('/api/2/session/')
-      .reply(200, '{}')
+      .reply(200, '{}');
 
     const client = new BasicClient({
       username: 'username',

--- a/tests/test_auth.js
+++ b/tests/test_auth.js
@@ -64,14 +64,15 @@ describe('SmartFile Basic API client', () => {
         user: 'username',
         pass: 'password',
       })
-      .reply(200, '', { 'Set-Cookie': 'foo=bar' });
+      .reply(200, '', { 'Set-Cookie': ['foo=bar', 'csrftoken=ABCD'] });
 
     const api1 = nock(API_URL, {
       reqheaders: {
-        Cookie: 'foo=bar',
+        Cookie: ['foo=bar; csrftoken=ABCD'],
+        'X-CSRFToken': 'ABCD',
       },
     })
-      .get('/api/2/path/info/foobar')
+      .get('/api/2/session/')
       .basicAuth({
         user: 'username',
         pass: 'password',
@@ -85,14 +86,14 @@ describe('SmartFile Basic API client', () => {
     });
 
     // Ensure we can handle Set-Cookie.
-    client.login((loginError) => {
-      assert(!!loginError);
-      assert.strictEqual(1, client.cookies.getCookies(new CookieAccessInfo('fakeapi.foo', '/', false, false)).length);
+    client.login((login0Error) => {
+      assert(!!login0Error);
+      assert.strictEqual(2, client.cookies.getCookies(new CookieAccessInfo('fakeapi.foo', '/', false, false)).length);
       assert(api0.isDone());
 
       // Ensure we can handle Cookie.
-      client.info('/foobar', (infoError) => {
-        assert(!!infoError);
+      client.login((login1Error) => {
+        assert(!!login1Error);
         assert(api1.isDone());
         done();
       });

--- a/tests/test_auth.js
+++ b/tests/test_auth.js
@@ -57,7 +57,7 @@ describe('SmartFile Basic API client', () => {
     });
   });
 
-  it('can start a session', (done) => {
+  it('can start a session and handle csrftoken', (done) => {
     const api0 = nock(API_URL)
       .post('/api/2/session/')
       .basicAuth({
@@ -85,12 +85,20 @@ describe('SmartFile Basic API client', () => {
     client.login((login0Error) => {
       assert(!!login0Error);
       assert.strictEqual(2, client.cookies.getCookies(new CookieAccessInfo('fakeapi.foo', '/', false, false)).length);
+      // Credentials removed (using session key (JWT) now)
+      assert.strictEqual(undefined, client.options.auth);
       assert(api0.isDone());
 
-      // Ensure we can handle Cookie.
+      // Ensure we can handle Cookie and CSRF Token.
       client.login((login1Error) => {
         assert(!!login1Error);
         assert(api1.isDone());
+
+        // Ensure we can handle logout().
+        client.logout();
+        // Credentials restored.
+        assert.strictEqual('username:password', client.options.auth);
+
         done();
       });
     });


### PR DESCRIPTION
This PR adds general cookie handling. Callers can add cookies to the client: `client.cookies.setCookie(...)` etc. Also, cookies from the server are preserved and sent with future requests.

Cookie handling is used to implement `login()` and `logout()` methods which start and stop a session. When a session is started, the `sessionid` and `csrftoken` cookies will be sent with each request. Any authentication is disabled while the session is active. On `logout()` the `sessionid` and `csrftoken` cookies are removed and authentication is re-enabled.

Also, the CSRF token is sent via header for HTTP verbs that possibly mutate data. CSRF is required while session authentication is being used.