### PR TITLE
Better names for these functions.

### DIFF
--- a/lib/rest/client.js
+++ b/lib/rest/client.js
@@ -836,7 +836,7 @@ class Client {
     return this;
   }
 
-  login(callback, _options) {
+  startSession(callback, _options) {
     let options = {
       method: 'POST',
       uri: '/api/2/session/',
@@ -860,7 +860,7 @@ class Client {
     return this;
   }
 
-  logout(callback) {
+  endSession(callback) {
     const options = {
       method: 'DELETE',
       uri: '/api/2/session/',

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "smartfile-client",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "smartfile-client",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "description": "SmartFile API client for node.js.",
   "main": "index.js",
   "scripts": {

--- a/tests/test_auth.js
+++ b/tests/test_auth.js
@@ -101,20 +101,20 @@ describe('SmartFile Basic API client', () => {
     });
 
     // Ensure we can handle Set-Cookie.
-    client.login((login0Error) => {
+    client.startSession((login0Error) => {
       assert(!login0Error);
       assert.strictEqual(2, client.cookies.getCookies(new CookieAccessInfo('fakeapi.foo', '/', false, false)).length);
       // Credentials removed (using session key (JWT) now)
       assert(api0.isDone());
 
       // Ensure we can handle Cookie and CSRF Token.
-      client.login((login1Error) => {
+      client.startSession((login1Error) => {
         assert(!login1Error);
         assert(api1.isDone());
         assert(api2.isDone());
 
         // Ensure we can handle logout().
-        client.logout((logoutError) => {
+        client.endSession((logoutError) => {
           // Credentials restored.
           assert(!logoutError);
           assert(api3.isDone());


### PR DESCRIPTION
I renamed these because when using authentication as provided by `BasicClient`, every request is authenticated. This set of functions effectively switch to session authentication and back again, they do not toggle authentication wholly.