### PR TITLE
Array length must be evaluated to determine empty array

### DIFF
--- a/lib/rest/client.js
+++ b/lib/rest/client.js
@@ -220,7 +220,7 @@ class Client {
     let usingSession = false;
 
     // Inject cookies from jar into request headers.
-    if (reqCookies) {
+    if (reqCookies.length) {
       const cookieStrings = [];
       for (let i = 0; i < reqCookies.length; i++) {
         if (reqCookies[i].name === 'sessionid') {


### PR DESCRIPTION
An array object will always be truthy. The length must be checked to determine if it is empty