### PR TITLE
Fix cookie handling

### DIFF
--- a/lib/rest/client.js
+++ b/lib/rest/client.js
@@ -213,7 +213,7 @@ class Client {
     }
 
     // We need URL details for handling cookies.
-    const cai = new CookieAccessInfo(reqUrl.host, reqUrl.pathname, (reqUrl.protocol === 'https:'), false);
+    const cai = new CookieAccessInfo(reqUrl.host, '/', true, false);
 
     // Any cookies for this request?
     const reqCookies = this.cookies.getCookies(cai);

--- a/lib/rest/client.js
+++ b/lib/rest/client.js
@@ -141,7 +141,6 @@ class Client {
     this.baseUrl = opts.baseUrl || process.env.SMARTFILE_API_URL || BASE_URL;
 
     this.options = {
-      auth: opts.auth,
       timeout: opts.timeout || 30000,
       headers: opts.headers,
     };


### PR DESCRIPTION
Cookies were not matching because the `path` is always `/` and the `secure` flag is always set.
The `auth` part of options should only be set by the `authenticate` implementation