### PR TITLE
Mergeops

### DIFF
--- a/lib/rest/client.js
+++ b/lib/rest/client.js
@@ -160,12 +160,14 @@ class Client {
     }
 
     // Deep copy global options so our local options don't pollute them.
-    const reqOptions = JSON.parse(JSON.stringify(this.options));
-    reqOptions.method = options.method;
-
-    if (!reqOptions.headers) {
-      reqOptions.headers = {};
+    const reqOptions = {
+      ...this.options,
+      method: options.method
     }
+
+    reqOptions.headers = {
+      ...reqOptions.headers,
+    };
 
     if (options.headers) {
       // Merge in any request-specific headers.
@@ -227,10 +229,7 @@ class Client {
         }
         cookieStrings.push(reqCookies[i].toValueString());
       }
-      reqOptions.headers = {
-        ...reqOptions.headers,
-        Cookie: cookieStrings.join('; '),
-      };
+      reqOptions.headers.Cookie = cookieStrings.join('; ');
     }
 
     // Handle CSRF token for some requests.

--- a/lib/rest/client.js
+++ b/lib/rest/client.js
@@ -162,8 +162,8 @@ class Client {
     // Deep copy global options so our local options don't pollute them.
     const reqOptions = {
       ...this.options,
-      method: options.method
-    }
+      method: options.method,
+    };
 
     reqOptions.headers = {
       ...reqOptions.headers,


### PR DESCRIPTION
The method used to merge options `JSON.parse(JSON.stringify(options))` disallowed setting an option that required an object (such as `options.agent`). The object would be converted to a dictionary.

Use spreading to merge options instead, which will preserve types.