### PR TITLE
Fetch next page of results in parallel with callback.

### DIFF
--- a/lib/fs/filesystem.js
+++ b/lib/fs/filesystem.js
@@ -560,7 +560,7 @@ class FileSystem {
       ...opts,
     };
     // Default to false.
-    options.incremental = opts.incremental || false;
+    options.incremental = (opts && opts.incremental) || false;
 
     // API arguments.
     const reqOptions = {

--- a/lib/fs/filesystem.js
+++ b/lib/fs/filesystem.js
@@ -557,15 +557,16 @@ class FileSystem {
     const end = OPERATION.startTimer({ opName: 'readdirstats' });
 
     const options = {
-      incremental: false,
       ...opts,
     };
+    // Default to false.
+    options.incremental = opts.incremental || false;
 
     // API arguments.
     const reqOptions = {
       qs: {
         children: 'true',
-        limit: 1024,
+        limit: 100,
       },
     };
 

--- a/lib/rest/client.js
+++ b/lib/rest/client.js
@@ -527,7 +527,7 @@ class Client {
       const pageOptions = { ...opts };
       if (page) {
         pageOptions.qs.page = page;
-        pageOptions.qs.limit = 1024;
+        pageOptions.qs.limit = 100;
       }
 
       // Use an intermediary callback to handle paging.
@@ -548,16 +548,18 @@ class Client {
           children[i].time = toUtcTs(children[i].time);
         }
 
-        if (callback(e, children, json) === true) {
-          return;
-        }
-
         // If more pages are available, Call the function recursively to fetch
-        // them. Use setImmediate so as not to block the event loop.
+        // them. Use setImmediate() so that fetching the next page can happen
+        // in parallel.
         if (json.page < json.pages) {
           logger.debug('getting next page of results');
           setImmediate(getInfoPage, client, pageOptions, json.page + 1);
-        } else if (json.page === json.pages) {
+        }
+
+        // Invoke callback with page of results.
+        callback(e, children, json);
+
+        if (json.page === json.pages) {
           logger.debug('final page of results reached');
           // Send a final callback with null JSON to indicate completion.
           CHILDREN.observe(pollCount);

--- a/lib/rest/client.js
+++ b/lib/rest/client.js
@@ -162,8 +162,8 @@ class Client {
     // Deep copy global options so our local options don't pollute them.
     const reqOptions = {
       ...this.options,
-      method: options.method
-    }
+      method: options.method,
+    };
 
     reqOptions.headers = {
       ...reqOptions.headers,

--- a/tests/test_fs.js
+++ b/tests/test_fs.js
@@ -153,7 +153,7 @@ describe('File System Abstraction', () => {
   it('can readdir()', (done) => {
     const api = server
       .get('/api/2/path/info/foobar')
-      .query({ children: 'true', limit: 1024 })
+      .query({ children: 'true', limit: 100 })
       .reply(200, '{ "name": "foobar", "path": "/foobar", "children": [{"name": "foo", "path": "/foobar/foo", "size": 10 }, {"name": "bar", "path": "/foobar/bar", "size": 10}]}');
 
     sffs.readdir('/foobar', (e, json) => {
@@ -170,7 +170,7 @@ describe('File System Abstraction', () => {
   it('can stat() from cache', (done) => {
     const api = server
       .get('/api/2/path/info/foobar')
-      .query({ children: 'true', limit: 1024 })
+      .query({ children: 'true', limit: 100 })
       .reply(200, '{ "children": [{"name": "foo", "path": "/foobar/foo", "size": 10 }, {"name": "bar", "path": "/foobar/bar", "size": 10}]}');
 
     sffs.readdir('/foobar', (readdirError, readDirJson) => {
@@ -191,12 +191,12 @@ describe('File System Abstraction', () => {
   it('can readdirstats() incrementally', (done) => {
     const api0 = server
       .get('/api/2/path/info/foobar')
-      .query({ children: 'true', limit: 1024 })
+      .query({ children: 'true', limit: 100 })
       .reply(200, '{ "page": 1, "pages": 2, "name": "foobar", "path": "/foobar", "children": [{"name": "foo", "path": "/foobar/foo", "size": 10 }, {"name": "bar", "path": "/foobar/bar", "size": 10}]}');
 
     const api1 = server
       .get('/api/2/path/info/foobar')
-      .query({ children: 'true', limit: 1024, page: 2 })
+      .query({ children: 'true', limit: 100, page: 2 })
       .reply(200, '{ "page": 2, "pages": 2, "name": "foobar", "path": "/foobar", "children": [{"name": "baz", "path": "/foobar/baz", "size": 10 }, {"name": "quux", "path": "/foobar/quux", "size": 10}]}');
 
     let calls = 0;

--- a/tests/test_rest.js
+++ b/tests/test_rest.js
@@ -245,7 +245,7 @@ describe('REST API client', () => {
   it('can retrieve a directory listing', (done) => {
     const api = server
       .get('/api/2/path/info/foobar')
-      .query({ children: 'true', limit: 1024 })
+      .query({ children: 'true', limit: 100 })
       .reply(200, '{ "page": 1, "pages": 1, "children": [{ "name": "foo" }, { "name": "bar" }]}');
 
     let calls = 0;
@@ -269,18 +269,18 @@ describe('REST API client', () => {
           assert.fail('too many callbacks');
           break;
       }
-    }, { qs: { children: 'true', limit: 1024 } });
+    }, { qs: { children: 'true', limit: 100 } });
   });
 
   it('can retrieve a multi-page directory listing', (done) => {
     const api0 = server
       .get('/api/2/path/info/foobar')
-      .query({ children: 'true', limit: 1024 })
+      .query({ children: 'true', limit: 100 })
       .reply(200, '{ "page": 1, "pages": 2, "children": [{ "name": "foo" }, { "name": "bar" }]}');
 
     const api1 = server
       .get('/api/2/path/info/foobar')
-      .query({ children: 'true', limit: 1024, page: 2 })
+      .query({ children: 'true', limit: 100, page: 2 })
       .reply(200, '{ "page": 2, "pages": 2, "children": [{ "name": "baz" }, { "name": "quux" }]}');
 
     let calls = 0;
@@ -310,7 +310,7 @@ describe('REST API client', () => {
           assert.fail('too many callbacks');
           break;
       }
-    }, { qs: { children: 'true', limit: 1024 } });
+    }, { qs: { children: 'true', limit: 100 } });
   });
 
   it('can create a directory', (done) => {


### PR DESCRIPTION
During a directory listing, use `setImmediate()` to fetch the next page of results in parallel with the callback for the current page of results.

Obviously these won't strictly run in parallel, but the fetch should be started, and once the first callback in that execution path is encountered, execution will yield, allowing the current page callback to execute.

In other words, the HTTP request should be in-flight while the current page is being rendered to the caller.

I also reduced the page size to 100, since that is the hard max on the server side.