### PR TITLE
Don't clobber user-supplied options.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,7 @@ coverage:
 
 .PHONY: version
 version:
-	npm version ${VERSION}
+	npm version --allow-same-version ${VERSION}
 
 .PHONY: clean
 clean:

--- a/lib/fs/filesystem.js
+++ b/lib/fs/filesystem.js
@@ -543,7 +543,7 @@ class FileSystem {
         },
       },
       ...opts,
-    }
+    };
 
     // https://nodejs.org/api/fs.html#fs_fs_readdir_path_options_callback
     this.readdirstats(path, (e, infos) => {
@@ -577,7 +577,7 @@ class FileSystem {
       },
       ...opts,
     };
-  
+
     // Buffer when not incremental.
     const infos = reqOptions.incremental ? null : [];
 

--- a/lib/fs/filesystem.js
+++ b/lib/fs/filesystem.js
@@ -575,7 +575,6 @@ class FileSystem {
           limit: (opts && opts.limit) || 100,
         },
       },
-      ...opts,
     };
 
     // Buffer when not incremental.

--- a/lib/fs/filesystem.js
+++ b/lib/fs/filesystem.js
@@ -64,16 +64,16 @@ class FileSystem {
       recurse = false;
     }
 
-    logger.debug(`Removing path "${path}" from cache.`);
+    logger.silly(`Removing path "${path}" from cache.`);
     delete this.statCache[path];
 
     if (recurse) {
+      logger.debug(`Recursively removing path "${path}" from cache.`);
       // eslint-disable-next-line no-param-reassign
       path = (path.endsWith('/')) ? path : `${path}/`;
 
       Object.keys(this.statCache).forEach((key) => {
         if (key.startsWith(path)) {
-          logger.debug(`Recursively removing path "${key}" from cache.`);
           removed.push(this.statCache[key]);
           delete this.statCache[key];
         }
@@ -91,7 +91,7 @@ class FileSystem {
       return;
     }
 
-    logger.debug(`Adding "${path}" to cache.`);
+    logger.silly(`Adding "${path}" to cache.`);
     this.statCache[path] = obj;
   }
 
@@ -556,22 +556,20 @@ class FileSystem {
   readdirstats(path, callback, opts) {
     const end = OPERATION.startTimer({ opName: 'readdirstats' });
 
-    const options = {
-      ...opts,
-    };
-    // Default to false.
-    options.incremental = (opts && opts.incremental) || false;
-
-    // API arguments.
-    const reqOptions = {
+    const defaults = {
+      incremental: false,
       qs: {
         children: 'true',
         limit: 100,
       },
     };
+    const reqOptions = {
+      ...defaults,
+      ...opts,
+    };
 
     // Buffer when not incremental.
-    const infos = options.incremental ? null : [];
+    const infos = reqOptions.incremental ? null : [];
 
     this._clearCache(0, 1);
 
@@ -604,14 +602,14 @@ class FileSystem {
 
       // Cache page of results.
       for (let i = 0; i < page.length; i++) {
-        if (!options.incremental) {
+        if (!reqOptions.incremental) {
           infos.push(page[i]);
         }
 
         this._addCache(page[i].path, page[i], 1, 2);
       }
 
-      if (options.incremental) {
+      if (reqOptions.incremental) {
         callback(null, page);
       }
     }, reqOptions);

--- a/lib/fs/filesystem.js
+++ b/lib/fs/filesystem.js
@@ -569,7 +569,7 @@ class FileSystem {
 
     const reqOptions = {
       ...{
-        incremental: false,
+        incremental: (opts && opts.incremental) || false,
         qs: {
           children: true,
           limit: (opts && opts.limit) || 100,

--- a/lib/fs/filesystem.js
+++ b/lib/fs/filesystem.js
@@ -533,7 +533,18 @@ class FileSystem {
     });
   }
 
-  readdir(path, callback, options) {
+  readdir(path, callback, opts) {
+    const reqOptions = {
+      ...{
+        incremental: false,
+        qs: {
+          children: true,
+          limit: (opts && opts.limit) || 100,
+        },
+      },
+      ...opts,
+    }
+
     // https://nodejs.org/api/fs.html#fs_fs_readdir_path_options_callback
     this.readdirstats(path, (e, infos) => {
       if (e) {
@@ -550,24 +561,23 @@ class FileSystem {
       }
 
       callback(null, names);
-    }, options);
+    }, reqOptions);
   }
 
   readdirstats(path, callback, opts) {
     const end = OPERATION.startTimer({ opName: 'readdirstats' });
 
-    const defaults = {
-      incremental: false,
-      qs: {
-        children: 'true',
-        limit: 100,
-      },
-    };
     const reqOptions = {
-      ...defaults,
+      ...{
+        incremental: false,
+        qs: {
+          children: true,
+          limit: (opts && opts.limit) || 100,
+        },
+      },
       ...opts,
     };
-
+  
     // Buffer when not incremental.
     const infos = reqOptions.incremental ? null : [];
 

--- a/lib/rest/client.js
+++ b/lib/rest/client.js
@@ -527,7 +527,7 @@ class Client {
       const pageOptions = { ...opts };
       if (page) {
         pageOptions.qs.page = page;
-        pageOptions.qs.limit = 100;
+        pageOptions.qs.limit = options.limit || 100;
       }
 
       // Use an intermediary callback to handle paging.
@@ -552,7 +552,7 @@ class Client {
         // them. Use setImmediate() so that fetching the next page can happen
         // in parallel.
         if (json.page < json.pages) {
-          logger.debug('getting next page of results');
+          logger.debug(`getting page ${json.page + 1} of results`);
           setImmediate(getInfoPage, client, pageOptions, json.page + 1);
         }
 
@@ -560,7 +560,7 @@ class Client {
         callback(e, children, json);
 
         if (json.page === json.pages) {
-          logger.debug('final page of results reached');
+          logger.debug(`final page ${json.page} reached`);
           // Send a final callback with null JSON to indicate completion.
           CHILDREN.observe(pollCount);
           callback(e, null);

--- a/lib/rest/client.js
+++ b/lib/rest/client.js
@@ -524,10 +524,15 @@ class Client {
 
     function getInfoPage(client, opts, page) {
       pollCount += 1;
-      const pageOptions = { ...opts };
+      const pageOptions = {
+        ...opts,
+        qs: {
+          children: true,
+          limit: options.qs.limit || 100,
+        }
+      };
       if (page) {
         pageOptions.qs.page = page;
-        pageOptions.qs.limit = options.qs.limit || 100;
       }
 
       // Use an intermediary callback to handle paging.

--- a/lib/rest/client.js
+++ b/lib/rest/client.js
@@ -529,7 +529,7 @@ class Client {
         qs: {
           children: true,
           limit: options.qs.limit || 100,
-        }
+        },
       };
       if (page) {
         pageOptions.qs.page = page;

--- a/lib/rest/client.js
+++ b/lib/rest/client.js
@@ -527,7 +527,7 @@ class Client {
       const pageOptions = { ...opts };
       if (page) {
         pageOptions.qs.page = page;
-        pageOptions.qs.limit = options.limit || 100;
+        pageOptions.qs.limit = options.qs.limit || 100;
       }
 
       // Use an intermediary callback to handle paging.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "smartfile-client",
-  "version": "1.0.16",
+  "version": "1.0.17",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "smartfile-client",
-  "version": "1.0.15",
+  "version": "1.0.16",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "smartfile-client",
-  "version": "1.0.15",
+  "version": "1.0.16",
   "description": "SmartFile API client for node.js.",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "smartfile-client",
-  "version": "1.0.16",
+  "version": "1.0.17",
   "description": "SmartFile API client for node.js.",
   "main": "index.js",
   "scripts": {

--- a/tests/test_fs.js
+++ b/tests/test_fs.js
@@ -191,15 +191,16 @@ describe('File System Abstraction', () => {
   it('can readdirstats() incrementally', (done) => {
     const api0 = server
       .get('/api/2/path/info/foobar')
-      .query({ children: 'true', limit: 100 })
+      .query({ children: 'true', limit: 2 })
       .reply(200, '{ "page": 1, "pages": 2, "name": "foobar", "path": "/foobar", "children": [{"name": "foo", "path": "/foobar/foo", "size": 10 }, {"name": "bar", "path": "/foobar/bar", "size": 10}]}');
 
     const api1 = server
       .get('/api/2/path/info/foobar')
-      .query({ children: 'true', limit: 100, page: 2 })
+      .query({ children: 'true', limit: 2, page: 2 })
       .reply(200, '{ "page": 2, "pages": 2, "name": "foobar", "path": "/foobar", "children": [{"name": "baz", "path": "/foobar/baz", "size": 10 }, {"name": "quux", "path": "/foobar/quux", "size": 10}]}');
 
     let calls = 0;
+    debugger;
     sffs.readdirstats('/foobar', (e, json) => {
       // eslint-disable-next-line no-plusplus
       switch (++calls) {
@@ -233,7 +234,10 @@ describe('File System Abstraction', () => {
           assert.fail('too many callbacks');
           break;
       }
-    }, { incremental: true });
+    }, {
+      incremental: true,
+      limit: 2,
+    });
   });
 
   it('can open a write stream', (done) => {

--- a/tests/test_fs.js
+++ b/tests/test_fs.js
@@ -156,6 +156,7 @@ describe('File System Abstraction', () => {
       .query({ children: 'true', limit: 100 })
       .reply(200, '{ "name": "foobar", "path": "/foobar", "children": [{"name": "foo", "path": "/foobar/foo", "size": 10 }, {"name": "bar", "path": "/foobar/bar", "size": 10}]}');
 
+    debugger;
     sffs.readdir('/foobar', (e, json) => {
       assert(sffs.statCache['/foobar']);
       assert(sffs.statCache['/foobar/foo']);

--- a/tests/test_fs.js
+++ b/tests/test_fs.js
@@ -200,7 +200,6 @@ describe('File System Abstraction', () => {
       .reply(200, '{ "page": 2, "pages": 2, "name": "foobar", "path": "/foobar", "children": [{"name": "baz", "path": "/foobar/baz", "size": 10 }, {"name": "quux", "path": "/foobar/quux", "size": 10}]}');
 
     let calls = 0;
-    debugger;
     sffs.readdirstats('/foobar', (e, json) => {
       // eslint-disable-next-line no-plusplus
       switch (++calls) {

--- a/tests/test_fs.js
+++ b/tests/test_fs.js
@@ -201,7 +201,8 @@ describe('File System Abstraction', () => {
 
     let calls = 0;
     sffs.readdirstats('/foobar', (e, json) => {
-      switch (calls += 1) {
+      // eslint-disable-next-line no-plusplus
+      switch (++calls) {
         case 1:
           assertNoError(e);
           assert(sffs.statCache['/foobar']);

--- a/tests/test_fs.js
+++ b/tests/test_fs.js
@@ -156,7 +156,6 @@ describe('File System Abstraction', () => {
       .query({ children: 'true', limit: 100 })
       .reply(200, '{ "name": "foobar", "path": "/foobar", "children": [{"name": "foo", "path": "/foobar/foo", "size": 10 }, {"name": "bar", "path": "/foobar/bar", "size": 10}]}');
 
-    debugger;
     sffs.readdir('/foobar', (e, json) => {
       assert(sffs.statCache['/foobar']);
       assert(sffs.statCache['/foobar/foo']);


### PR DESCRIPTION
Options from caller were ignored within `readdirstats()`. This change allows the caller to choose page limit etc.

I also reduced some of the logging output (silly level) and added some information to some log messages.