### PR TITLE
Upload error handling.

### DIFF
--- a/lib/rest/client.js
+++ b/lib/rest/client.js
@@ -633,6 +633,13 @@ class Client {
       req
         .on('response', (res) => {
           parseJson(req, res, (e, r, json) => {
+            // This endpoint returns 200 even on error, inspect JSON for error
+            // details.
+            if (json && json.detail) {
+              // An error occurred.
+              // eslint-disable-next-line no-param-reassign
+              e = new Error(json.detail);
+            }
             callback(e, json);
           });
         })

--- a/lib/rest/client.js
+++ b/lib/rest/client.js
@@ -639,6 +639,10 @@ class Client {
               // An error occurred.
               // eslint-disable-next-line no-param-reassign
               e = new Error(json.detail);
+              // Add HTTP status code (if provided.)
+              if (json.status) {
+                e.statusCode = json.status;
+              }
             }
             callback(e, json);
           });

--- a/tests/test_fs.js
+++ b/tests/test_fs.js
@@ -295,9 +295,10 @@ describe('File System Abstraction', () => {
   it('reports errors correctly during upload', (done) => {
     const api = server
       .put('/api/3/path/data/foobar')
-      .reply(200, '{ "detail": "Some error happened" }');
+      .reply(200, '{ "status": 400, "detail": "Some error happened" }');
 
     const s = sffs.createWriteStream('/foobar', (e) => {
+      assert.strictEqual(e.statusCode, 400);
       assert.strictEqual(e.message, 'Some error happened');
       assert(api.isDone());
       done();

--- a/tests/test_fs.js
+++ b/tests/test_fs.js
@@ -295,10 +295,10 @@ describe('File System Abstraction', () => {
   it('reports errors correctly during upload', (done) => {
     const api = server
       .put('/api/3/path/data/foobar')
-      .reply(500, 'Internal server error');
+      .reply(200, '{ "detail": "Some error happened" }');
 
     const s = sffs.createWriteStream('/foobar', (e) => {
-      assert.strictEqual(e.statusCode, 500);
+      assert.strictEqual(e.message, 'Some error happened');
       assert(api.isDone());
       done();
     });


### PR DESCRIPTION
The lua upload handler prevents upload errors from being reflected in the HTTP status code. Instead the API client must inspect the JSON returned from the API to detect an error.

https://github.com/btimby/nginx-lua-chunkedup/issues/15

This will get the http status code if available. The lua chunkedup module will provide it:

https://github.com/btimby/nginx-lua-chunkedup/pull/16