### PR TITLE
Support limited fields for directory listings

### DIFF
--- a/lib/fs/filesystem.js
+++ b/lib/fs/filesystem.js
@@ -573,6 +573,7 @@ class FileSystem {
         qs: {
           children: true,
           limit: (opts && opts.limit) || 100,
+          ...(opts.fields && { fields: opts.fields }),
         },
       },
     };

--- a/lib/rest/client.js
+++ b/lib/rest/client.js
@@ -155,7 +155,12 @@ class Client {
 
     if (options.qs) {
       Object.keys(options.qs).forEach((key) => {
-        reqUrl.searchParams.set(key, options.qs[key]);
+        const value = options.qs[key];
+        if (Array.isArray(value)) {
+          value.forEach((v) => reqUrl.searchParams.append(key, v));
+        } else {
+          reqUrl.searchParams.set(key, value);
+        }
       });
     }
 
@@ -529,6 +534,7 @@ class Client {
         qs: {
           children: true,
           limit: options.qs.limit || 100,
+          ...(opts.qs.fields && { fields: opts.qs.fields }),
         },
       };
       if (page) {


### PR DESCRIPTION
Uses the query parameter `fields` to request a limited set of fields for directory listings