### PR TITLE
Send a referer header for CSRF validation.

### DIFF
--- a/lib/rest/client.js
+++ b/lib/rest/client.js
@@ -244,7 +244,7 @@ class Client {
         reqOptions.headers = {
           ...reqOptions.headers,
           // Add CSRF token to headers.
-          'Referer': reqUrl.toString(),
+          Referer: reqUrl.toString(),
           'X-CSRFToken': csrfCookie.value,
         };
       }

--- a/lib/rest/client.js
+++ b/lib/rest/client.js
@@ -238,12 +238,13 @@ class Client {
     }
 
     // Handle CSRF token for some requests.
-    if (['GET', 'HEAD', 'OPTIONS', 'TRACE'].indexOf(reqOptions.method.toUpperCase()) === -1) {
+    if (usingSession && ['GET', 'HEAD', 'OPTIONS', 'TRACE'].indexOf(reqOptions.method.toUpperCase()) === -1) {
       const csrfCookie = this.cookies.getCookie('csrftoken', cai);
       if (csrfCookie) {
         reqOptions.headers = {
           ...reqOptions.headers,
           // Add CSRF token to headers.
+          'Referer': reqUrl.toString(),
           'X-CSRFToken': csrfCookie.value,
         };
       }

--- a/tests/test_auth.js
+++ b/tests/test_auth.js
@@ -70,6 +70,7 @@ describe('SmartFile Basic API client', () => {
       reqheaders: {
         cookie: 'sessionid=bar; csrftoken=ABCD',
         'x-csrftoken': 'ABCD',
+        'Referer': 'http://fakeapi.foo/api/2/session/',
       },
     })
       .post('/api/2/session/')
@@ -88,6 +89,7 @@ describe('SmartFile Basic API client', () => {
       reqheaders: {
         cookie: 'sessionid=bar; csrftoken=ABCD',
         'x-csrftoken': 'ABCD',
+        'Referer': 'http://fakeapi.foo/api/2/session/',
       },
     })
       .delete('/api/2/session/')

--- a/tests/test_auth.js
+++ b/tests/test_auth.js
@@ -70,7 +70,7 @@ describe('SmartFile Basic API client', () => {
       reqheaders: {
         cookie: 'sessionid=bar; csrftoken=ABCD',
         'x-csrftoken': 'ABCD',
-        'Referer': 'http://fakeapi.foo/api/2/session/',
+        Referer: 'http://fakeapi.foo/api/2/session/',
       },
     })
       .post('/api/2/session/')
@@ -89,7 +89,7 @@ describe('SmartFile Basic API client', () => {
       reqheaders: {
         cookie: 'sessionid=bar; csrftoken=ABCD',
         'x-csrftoken': 'ABCD',
-        'Referer': 'http://fakeapi.foo/api/2/session/',
+        Referer: 'http://fakeapi.foo/api/2/session/',
       },
     })
       .delete('/api/2/session/')


### PR DESCRIPTION
Django requires a referer header for CSRF validation when making a secure connection. CSRF is required when doing session authentication.