### PR TITLE
Handle options / headers when opening streams.

### DIFF
--- a/lib/fs/filesystem.js
+++ b/lib/fs/filesystem.js
@@ -261,10 +261,10 @@ class FileSystem {
     if (typeof _options === 'function') {
       // options omitted, shift.
       callback = _options;
-      options = {};
+      options = { headers: {} };
     } else {
       callback = _callback;
-      options = _options;
+      options = { ..._options, headers: {} };
     }
 
     if (typeof callback !== 'function') {
@@ -273,7 +273,7 @@ class FileSystem {
 
     if (options && options.offset) {
       // transform fs-style options to HTTP options.
-      options.headers = { Range: `bytes=${options.offset}-` };
+      options.headers.Range = `bytes=${options.offset}-`;
       delete options.offset;
     }
 
@@ -296,14 +296,14 @@ class FileSystem {
 
     if (typeof _options === 'function') {
       callback = _options;
-      options = {};
+      options = { headers: {} };
     } else {
       callback = _callback;
-      options = _options;
+      options = { ..._options, headers: {} };
     }
 
     if (options && options.offset) {
-      options.headers = { Range: `bytes=${options.offset}-` };
+      options.headers.Range = `bytes=${options.offset}-`;
       delete options.offset;
 
       if (options.timestamp) {

--- a/lib/keys.js
+++ b/lib/keys.js
@@ -8,7 +8,7 @@ class Keys {
     this.keyCache = {};
   }
 
-  get(name, callback) {
+  get(name, callback, _options) {
     if (this.keyCache[name]) {
       // Satisfy from cache.
       callback(null, this.keyCache[name]);
@@ -16,10 +16,14 @@ class Keys {
       return;
     }
 
-    const options = {
+    let options = {
       method: 'get',
       uri: `/api/3/sshkeys/${this.username}/${name}`,
     };
+
+    if (_options) {
+      options = { ..._options, ...options };
+    }
 
     this.rest.requestJson(options, (e, r, json) => {
       if (e) {
@@ -32,11 +36,15 @@ class Keys {
     });
   }
 
-  list(callback) {
-    const options = {
+  list(callback, _options) {
+    let options = {
       method: 'get',
       uri: `/api/3/sshkeys/${this.username}/`,
     };
+
+    if (_options) {
+      options = { ..._options, ...options };
+    }
 
     this.rest.requestJson(options, (e, r, json) => {
       if (e) {
@@ -54,11 +62,15 @@ class Keys {
     });
   }
 
-  delete(name, callback) {
-    const options = {
+  delete(name, callback, _options) {
+    let options = {
       method: 'delete',
       uri: `/api/3/sshkeys/${this.username}/${name}`,
     };
+
+    if (_options) {
+      options = { ..._options, ...options };
+    }
 
     this.rest.request(options, (e) => {
       delete this.keyCache[name];
@@ -69,12 +81,16 @@ class Keys {
     }).end();
   }
 
-  save(obj, callback) {
-    const options = {
+  save(obj, callback, _options) {
+    let options = {
       method: 'put',
       uri: `/api/3/sshkeys/${this.username}/${obj.name}`,
       json: obj,
     };
+
+    if (_options) {
+      options = { ..._options, ...options };
+    }
 
     this.rest.requestJson(options, (e, r, json) => {
       if (e) {
@@ -90,12 +106,16 @@ class Keys {
     });
   }
 
-  update(name, obj, callback) {
-    const options = {
+  update(name, obj, callback, _options) {
+    let options = {
       method: 'patch',
       uri: `/api/3/sshkeys/${this.username}/${name}`,
       json: obj,
     };
+
+    if (_options) {
+      options = { ..._options, ...options };
+    }
 
     this.rest.requestJson(options, (e, r, json) => {
       if (e) {
@@ -112,7 +132,7 @@ class Keys {
     });
   }
 
-  find(givenKey, callback) {
+  find(givenKey, callback, _options) {
     this.list((e, keys) => {
       if (e) {
         if (callback) callback(e);
@@ -132,7 +152,7 @@ class Keys {
       }
 
       callback(null, null);
-    });
+    }, _options);
   }
 }
 

--- a/lib/rest/client.js
+++ b/lib/rest/client.js
@@ -379,6 +379,7 @@ class Client {
         method: 'GET',
         uri: '/api/2/task/',
         path: `${json0.uuid}/`,
+        headers: (options && options.headers),
       };
       let pollInterval = MIN_POLL_INTERVAL;
 


### PR DESCRIPTION
Pass options along with key api calls. Also, was clobbering options in `createReadStream` and `createWriteStream`.