### PR TITLE
When creating a read or write stream, pass given headers.

### DIFF
--- a/lib/fs/filesystem.js
+++ b/lib/fs/filesystem.js
@@ -264,7 +264,7 @@ class FileSystem {
       options = { headers: {} };
     } else {
       callback = _callback;
-      options = { ..._options, headers: {} };
+      options = { ..._options };
     }
 
     if (typeof callback !== 'function') {
@@ -273,6 +273,9 @@ class FileSystem {
 
     if (options && options.offset) {
       // transform fs-style options to HTTP options.
+      if (!options.headers) {
+        options.headers = {};
+      }
       options.headers.Range = `bytes=${options.offset}-`;
       delete options.offset;
     }
@@ -299,10 +302,13 @@ class FileSystem {
       options = { headers: {} };
     } else {
       callback = _callback;
-      options = { ..._options, headers: {} };
+      options = { ..._options };
     }
 
     if (options && options.offset) {
+      if (!options.headers) {
+        options.headers = {};
+      }
       options.headers.Range = `bytes=${options.offset}-`;
       delete options.offset;
 


### PR DESCRIPTION
This should allow the `X-Unique-ID` header to be passed along with upload and download requests.