### PR TITLE
Properly print task errors

### DIFF
--- a/lib/rest/client.js
+++ b/lib/rest/client.js
@@ -426,7 +426,7 @@ class Client {
                 endpoint: pollOptions.uri,
               }, pollCount);
 
-              resError = new Error(`Task failed: result.result.errors=${errors}`);
+              resError = new Error(`Task failed: result.result.errors=${JSON.stringify(errors)}`);
               resError.statusCode = r1.statusCode;
               resError.request = req;
               callback(resError, r1, json1);
@@ -435,7 +435,7 @@ class Client {
             case 'SUCCESS':
               // Sometimes an error occurs during the operation (partial failure).
               if (errors) {
-                resError = new Error(`Partial failure: result.result.errors=${errors}`);
+                resError = new Error(`Partial failure: result.result.errors=${JSON.stringify(errors)}`);
                 resError.statusCode = r1.statusCode;
 
                 OPERATION.observe({


### PR DESCRIPTION
Task errors are objects. This change formats them properly so that they are made into strings rather than `[object Object]`: https://sentry.lumanox.io/organizations/lumanox/issues/37126/events/e79e564c3d1e4bf0a92d5c783ca8f45d/?project=24&statsPeriod=14d