### PR TITLE
Don't attach heavyweight request object to error.

### DIFF
--- a/lib/fs/filesystem.js
+++ b/lib/fs/filesystem.js
@@ -147,7 +147,7 @@ class FileSystem {
   rmdir(path, callback, options) {
     return operationWrapper(this.rest, 'delete', [path], (e, json) => {
       if (e && e.statusCode === 404
-        && e.request.path === '/api/2/path/oper/remove/') {
+        && e.path === '/api/2/path/oper/remove/') {
         this._delCache(path, 0, 1, 2);
         // Mask out the error, and forge a fake response.
         callback(null, {

--- a/lib/fs/filesystem.js
+++ b/lib/fs/filesystem.js
@@ -129,6 +129,7 @@ class FileSystem {
           const newError = new Error('File not found');
           newError.statusCode = e.statusCode;
           newError.message = e.message;
+          newError.path = e.path;
           this._addCache(path, newError, 2);
         }
         callback(e);

--- a/lib/rest/client.js
+++ b/lib/rest/client.js
@@ -111,7 +111,7 @@ function parseJson(req, res, callback) {
         const resError = new Error(`${req.path} replied with: ${res.statusCode}`);
         resError.statusCode = res.statusCode;
         resError.statusMessage = res.statusMessage;
-        resError.request = req;
+        resError.path = req.path;
 
         if (callback) {
           callback(resError, res);
@@ -307,7 +307,7 @@ class Client {
 
         const resError = new Error(`${options.uri} replied with: ${res.statusCode}`);
         resError.statusCode = res.statusCode;
-        resError.request = req;
+        resError.path = req.path;
 
         if (callback) callback(resError, res);
       } else {
@@ -369,7 +369,7 @@ class Client {
     const req = this.requestJson(options, (req0Error, r0, json0) => {
       if (req0Error) {
         // eslint-disable-next-line no-param-reassign
-        req0Error.request = req;
+        req0Error.path = req.path;
         callback(req0Error, r0, json0);
         return;
       }
@@ -389,7 +389,7 @@ class Client {
         self.requestJson(pollOptions, (req1Error, r1, json1) => {
           if (req1Error) {
             // eslint-disable-next-line no-param-reassign
-            req1Error.request = req;
+            req1Error.path = req.path;
             callback(req1Error, r1, json1);
             return;
           }
@@ -428,7 +428,7 @@ class Client {
 
               resError = new Error(`Task failed: result.result.errors=${JSON.stringify(errors)}`);
               resError.statusCode = r1.statusCode;
-              resError.request = req;
+              resError.path = req.path;
               callback(resError, r1, json1);
               break;
 
@@ -457,7 +457,7 @@ class Client {
             default:
               resError = new Error(`Unexpected status: "${json1.result.status}"`);
               resError.statusCode = r1.statusCode;
-              resError.request = req;
+              resError.path = req.path;
               callback(resError, r1, json1);
               break;
           }


### PR DESCRIPTION
We use the request path in the library, since that is the only attribute we use, attach that instead.

Otherwise, the request object holds many resources, and because we return the error object, we cannot control it's lifetime.