### PR TITLE
Remove required call to whoami

### DIFF
--- a/lib/rest/client.js
+++ b/lib/rest/client.js
@@ -875,15 +875,14 @@ class Client {
     }
 
     // Attempt login, creating a session...
-    this.requestJson(options, (e) => {
+    this.requestJson(options, (e, r, json) => {
       if (e) {
         callback(e);
         return;
       }
 
       this.authenticated = true;
-      // NOTE: success, call whoami, logins often need user info.
-      this.whoami(callback, options);
+      callback(e, json);
     });
 
     return this;

--- a/tests/test_auth.js
+++ b/tests/test_auth.js
@@ -73,18 +73,9 @@ describe('SmartFile Basic API client', () => {
       },
     })
       .post('/api/2/session/')
-      .reply(201, '{}');
+      .reply(201, '{ "user": { "username": "username" } }');
 
     const api2 = nock(API_URL, {
-      reqheaders: {
-        cookie: 'sessionid=bar; csrftoken=ABCD',
-      },
-    })
-      .get('/api/2/whoami/')
-      .twice()
-      .reply(200, '{ "username": "user" }');
-
-    const api3 = nock(API_URL, {
       reqheaders: {
         cookie: 'sessionid=bar; csrftoken=ABCD',
         'x-csrftoken': 'ABCD',
@@ -108,16 +99,16 @@ describe('SmartFile Basic API client', () => {
       assert(api0.isDone());
 
       // Ensure we can handle Cookie and CSRF Token.
-      client.startSession((start1Error) => {
+      client.startSession((start1Error, json) => {
         assert(!start1Error);
         assert(api1.isDone());
-        assert(api2.isDone());
+        assert.strictEqual(json.user.username, 'username');
 
         // Ensure we can handle logout().
         client.endSession((endError) => {
           // Credentials restored.
           assert(!endError);
-          assert(api3.isDone());
+          assert(api2.isDone());
           assert.strictEqual(0, client.cookies.getCookies(new CookieAccessInfo('fakeapi.foo', '/', false, false)).length);
           done();
         });


### PR DESCRIPTION
The user may not want to fetch the user details and may want the results from the session API. The `whoami` method can be called specifically if desired