### PR TITLE
Return parent directory info from readdirstats.

### DIFF
--- a/lib/fs/filesystem.js
+++ b/lib/fs/filesystem.js
@@ -600,10 +600,11 @@ class FileSystem {
         end({ status: 'error' });
         return;
       }
+      let jsonClone = null;
 
       if (json) {
         // Don't modify the original.
-        const jsonClone = JSON.parse(JSON.stringify(json));
+        jsonClone = JSON.parse(JSON.stringify(json));
         // Remove some stuff that we don't want in cache.
         ['children', 'total', 'pages', 'page', 'per_page'].forEach((key) => {
           // eslint-disable-next-line no-param-reassign
@@ -616,7 +617,7 @@ class FileSystem {
       if (page === null) {
         // Note that infos is null when incremental.
         end({ status: 'success' });
-        callback(null, infos);
+        callback(null, infos, jsonClone);
         return;
       }
 
@@ -630,7 +631,7 @@ class FileSystem {
       }
 
       if (reqOptions.incremental) {
-        callback(null, page);
+        callback(null, page, jsonClone);
       }
     }, reqOptions);
   }


### PR DESCRIPTION
This is a small change to allow for efficient implementation of MLSD and MLST.

Currently, when you make a `readdirstats()` call, only the children of the given path are returned. This PR adds a 3rd parameter to the callback which provides the stat info for the given path itself.

This change allows all FTP listing commands (STAT, LIST, MLST, MLSD) to call `readdirstats()`, otherwise a separate `stat()` call would be necessary (even though the data is available in `readdirstats()` but is discarded).